### PR TITLE
Generate breakpoint classes with a mixin

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -135,6 +135,14 @@ If you want to change the styles for a selector at all of the declared screen si
 }
 ```
 
+To generate breakpoint classes for your styles, use the `.breakpoint-prefixes()` mixin. It will generate classes prepended with `xs-`, `sm-`, `md-`, `lg-`, `xl-` and `xxl-` that will only be active at the appropriate screen widths. It will also generate a class with no prefix that can be used at any screen width. It can be used like this:
+
+```
+.breakpoint-prefixes({
+  .@{breakpoint-prefix}my-class{ background: red; }
+});
+```
+
 # normalize.css
 
 Cardinal includes the 3rd-party library [normalize.css](https://github.com/necolas/normalize.css), which makes browsers render all elements more consistently and in line with modern web standards.

--- a/base/mixins/media-queries.less
+++ b/base/mixins/media-queries.less
@@ -152,3 +152,48 @@
   .screen-xl-min(@rules-xl);
   .screen-xxl-min(@rules-xxl);
 }
+
+//
+// Generate breakpoint classes
+//
+// Usage:
+//
+// .breakpoint-prefixes({
+//   .@{breakpoint-prefix}my-class{ background: red; }
+// });
+//
+
+.breakpoint-prefixes(@rules) {
+  @breakpoint-prefixes: xs, sm, md, lg, xl, xxl;
+  .write-classes(@class, @rules) {
+    & {
+      @breakpoint-prefix: @class;
+      @rules();
+    }
+  }
+  .breakpoint-prefixes-iterate(@i: length(@breakpoint-prefixes), @rules) when (@i > 0) {
+    .breakpoint-prefixes-iterate(@i - 1, @rules);
+    @prefix: extract(@breakpoint-prefixes, @i);
+    @prefix-class: ~"@{prefix}-";
+    & when (@prefix = xs) {
+      .screen-xs-min({ .write-classes(@prefix-class, @rules); })
+    }
+    & when (@prefix = sm) {
+      .screen-sm-min({ .write-classes(@prefix-class, @rules); })
+    }
+    & when (@prefix = md) {
+      .screen-md-min({ .write-classes(@prefix-class, @rules); })
+    }
+    & when (@prefix = lg) {
+      .screen-lg-min({ .write-classes(@prefix-class, @rules); })
+    }
+    & when (@prefix = xl) {
+      .screen-xl-min({ .write-classes(@prefix-class, @rules); })
+    }
+    & when (@prefix = xxl) {
+      .screen-xxl-min({ .write-classes(@prefix-class, @rules); })
+    }
+  }
+  .write-classes(~'', @rules);
+  .breakpoint-prefixes-iterate(length(@breakpoint-prefixes), @rules);
+}

--- a/layout/grids.less
+++ b/layout/grids.less
@@ -52,28 +52,8 @@
  * .grid-rtl = right-to-left
  */
 
-.grid-ltr {
-  direction: ltr;
-  text-align: left;
-
-  > .grid-item {
-    direction: rtl;
-    text-align: left;
-  }
-}
-
-.grid-rtl {
-  direction: rtl;
-  text-align: left;
-
-  > .grid-item {
-    direction: ltr;
-    text-align: left;
-  }
-}
-
-.screens({
-  .xs-grid-ltr {
+.breakpoint-prefixes({
+  .@{breakpoint-prefix}grid-ltr {
     direction: ltr;
     text-align: left;
 
@@ -83,107 +63,7 @@
     }
   }
 
-  .xs-grid-rtl {
-    direction: rtl;
-    text-align: left;
-
-    > .grid-item {
-      direction: ltr;
-      text-align: left;
-    }
-  }
-},{
-  .sm-grid-ltr {
-    direction: ltr;
-    text-align: left;
-
-    > .grid-item {
-      direction: rtl;
-      text-align: left;
-    }
-  }
-
-  .sm-grid-rtl {
-    direction: rtl;
-    text-align: left;
-
-    > .grid-item {
-      direction: ltr;
-      text-align: left;
-    }
-  }
-},{
-  .md-grid-ltr {
-    direction: ltr;
-    text-align: left;
-
-    > .grid-item {
-      direction: rtl;
-      text-align: left;
-    }
-  }
-
-  .md-grid-rtl {
-    direction: rtl;
-    text-align: left;
-
-    > .grid-item {
-      direction: ltr;
-      text-align: left;
-    }
-  }
-},{
-  .lg-grid-ltr {
-    direction: ltr;
-    text-align: left;
-
-    > .grid-item {
-      direction: rtl;
-      text-align: left;
-    }
-  }
-
-  .lg-grid-rtl {
-    direction: rtl;
-    text-align: left;
-
-    > .grid-item {
-      direction: ltr;
-      text-align: left;
-    }
-  }
-},{
-  .xl-grid-ltr {
-    direction: ltr;
-    text-align: left;
-
-    > .grid-item {
-      direction: rtl;
-      text-align: left;
-    }
-  }
-
-  .xl-grid-rtl {
-    direction: rtl;
-    text-align: left;
-
-    > .grid-item {
-      direction: ltr;
-      text-align: left;
-    }
-  }
-},{
-  .xxl-grid-ltr {
-    direction: ltr;
-    text-align: left;
-
-    > .grid-item {
-      direction: rtl;
-      text-align: left;
-    }
-  }
-
-  .xxl-grid-rtl {
+  .@{breakpoint-prefix}grid-rtl {
     direction: rtl;
     text-align: left;
 

--- a/layout/grids.less
+++ b/layout/grids.less
@@ -198,375 +198,57 @@
  * Grid gutters
  */
 
-// No gutters
-.gutter-0,
-.gutter-none {
-  margin-left: 0;
-}
-
-.gutter-0 > .grid-item,
-.gutter-none > .grid-item {
-  padding-left: 0;
-}
-
-// 1px gutters
-.gutter-1px {
-  .to-rem(margin-left, -@grid-gutter-1px);
-}
-
-.gutter-1px > .grid-item {
-  .to-rem(padding-left, @grid-gutter-1px);
-}
-
-// Half gutters
-[class~="gutter-1/2"],
-.gutter-half {
-  .to-rem(margin-left, -@grid-gutter-half);
-}
-
-[class~="gutter-1/2"] > .grid-item,
-.gutter-half > .grid-item {
-  .to-rem(padding-left, @grid-gutter-half);
-}
-
-// Whole gutters
-.gutter-1,
-.gutter-whole {
-  .to-rem(margin-left, -@grid-gutter-base);
-}
-
-.gutter-1 > .grid-item,
-.gutter-whole > .grid-item {
-  .to-rem(padding-left, @grid-gutter-base);
-}
-
-// Double gutters
-.gutter-2,
-.gutter-double {
-  .to-rem(margin-left, -@grid-gutter-double);
-}
-
-.gutter-2 > .grid-item,
-.gutter-double > .grid-item {
-  .to-rem(padding-left, @grid-gutter-double);
-}
-
-.screens({
+.breakpoint-prefixes({
   // No gutters
-  .xs-gutter-0,
-  .xs-gutter-none {
+  .@{breakpoint-prefix}gutter-0,
+  .@{breakpoint-prefix}gutter-none {
     margin-left: 0;
   }
 
-  .xs-gutter-0 > .grid-item,
-  .xs-gutter-none > .grid-item {
+  .@{breakpoint-prefix}gutter-0 > .grid-item,
+  .@{breakpoint-prefix}gutter-none > .grid-item {
     padding-left: 0;
   }
 
   // 1px gutters
-  .xs-gutter-1px {
+  .@{breakpoint-prefix}gutter-1px {
     .to-rem(margin-left, -@grid-gutter-1px);
   }
 
-  .xs-gutter-1px > .grid-item {
+  .@{breakpoint-prefix}gutter-1px > .grid-item {
     .to-rem(padding-left, @grid-gutter-1px);
   }
 
   // Half gutters
-  [class~="xs-gutter-1/2"],
-  .xs-gutter-half {
+  [class~="@{breakpoint-prefix}gutter-1/2"],
+  .@{breakpoint-prefix}gutter-half {
     .to-rem(margin-left, -@grid-gutter-half);
   }
 
-  [class~="xs-gutter-1/2"] > .grid-item,
-  .xs-gutter-half > .grid-item {
+  [class~="@{breakpoint-prefix}gutter-1/2"] > .grid-item,
+  .@{breakpoint-prefix}gutter-half > .grid-item {
     .to-rem(padding-left, @grid-gutter-half);
   }
 
   // Whole gutters
-  .xs-gutter-1,
-  .xs-gutter-whole {
+  .@{breakpoint-prefix}gutter-1,
+  .@{breakpoint-prefix}gutter-whole {
     .to-rem(margin-left, -@grid-gutter-base);
   }
 
-  .xs-gutter-1 > .grid-item,
-  .xs-gutter-whole > .grid-item {
+  .@{breakpoint-prefix}gutter-1 > .grid-item,
+  .@{breakpoint-prefix}gutter-whole > .grid-item {
     .to-rem(padding-left, @grid-gutter-base);
   }
 
   // Double gutters
-  .xs-gutter-2,
-  .xs-gutter-double {
+  .@{breakpoint-prefix}gutter-2,
+  .@{breakpoint-prefix}gutter-double {
     .to-rem(margin-left, -@grid-gutter-double);
   }
 
-  .xs-gutter-2 > .grid-item,
-  .xs-gutter-double > .grid-item {
-    .to-rem(padding-left, @grid-gutter-double);
-  }
-},{
-  // No gutters
-  .sm-gutter-0,
-  .sm-gutter-none {
-    margin-left: 0;
-  }
-
-  .sm-gutter-0 > .grid-item,
-  .sm-gutter-none > .grid-item {
-    padding-left: 0;
-  }
-
-  // 1px gutters
-  .sm-gutter-1px {
-    .to-rem(margin-left, -@grid-gutter-1px);
-  }
-
-  .sm-gutter-1px > .grid-item {
-    .to-rem(padding-left, @grid-gutter-1px);
-  }
-
-  // Half gutters
-  [class~="sm-gutter-1/2"],
-  .sm-gutter-half {
-    .to-rem(margin-left, -@grid-gutter-half);
-  }
-
-  [class~="sm-gutter-1/2"] > .grid-item,
-  .sm-gutter-half > .grid-item {
-    .to-rem(padding-left, @grid-gutter-half);
-  }
-
-  // Whole gutters
-  .sm-gutter-1,
-  .sm-gutter-whole {
-    .to-rem(margin-left, -@grid-gutter-base);
-  }
-
-  .sm-gutter-1 > .grid-item,
-  .sm-gutter-whole > .grid-item {
-    .to-rem(padding-left, @grid-gutter-base);
-  }
-
-  // Double gutters
-  .sm-gutter-2,
-  .sm-gutter-double {
-    .to-rem(margin-left, -@grid-gutter-double);
-  }
-
-  .sm-gutter-2 > .grid-item,
-  .sm-gutter-double > .grid-item {
-    .to-rem(padding-left, @grid-gutter-double);
-  }
-},{
-  // No gutters
-  .md-gutter-0,
-  .md-gutter-none {
-    margin-left: 0;
-  }
-
-  .md-gutter-0 > .grid-item,
-  .md-gutter-none > .grid-item {
-    padding-left: 0;
-  }
-
-  // 1px gutters
-  .md-gutter-1px {
-    .to-rem(margin-left, -@grid-gutter-1px);
-  }
-
-  .md-gutter-1px > .grid-item {
-    .to-rem(padding-left, @grid-gutter-1px);
-  }
-
-  // Half gutters
-  [class~="md-gutter-1/2"],
-  .md-gutter-half {
-    .to-rem(margin-left, -@grid-gutter-half);
-  }
-
-  [class~="md-gutter-1/2"] > .grid-item,
-  .md-gutter-half > .grid-item {
-    .to-rem(padding-left, @grid-gutter-half);
-  }
-
-  // Whole gutters
-  .md-gutter-1,
-  .md-gutter-whole {
-    .to-rem(margin-left, -@grid-gutter-base);
-  }
-
-  .md-gutter-1 > .grid-item,
-  .md-gutter-whole > .grid-item {
-    .to-rem(padding-left, @grid-gutter-base);
-  }
-
-  // Double gutters
-  .md-gutter-2,
-  .md-gutter-double {
-    .to-rem(margin-left, -@grid-gutter-double);
-  }
-
-  .md-gutter-2 > .grid-item,
-  .md-gutter-double > .grid-item {
-    .to-rem(padding-left, @grid-gutter-double);
-  }
-},{
-  // No gutters
-  .lg-gutter-0,
-  .lg-gutter-none {
-    margin-left: 0;
-  }
-
-  .lg-gutter-0 > .grid-item,
-  .lg-gutter-none > .grid-item {
-    padding-left: 0;
-  }
-
-  // 1px gutters
-  .lg-gutter-1px {
-    .to-rem(margin-left, -@grid-gutter-1px);
-  }
-
-  .lg-gutter-1px > .grid-item {
-    .to-rem(padding-left, @grid-gutter-1px);
-  }
-
-  // Half gutters
-  [class~="lg-gutter-1/2"],
-  .lg-gutter-half {
-    .to-rem(margin-left, -@grid-gutter-half);
-  }
-
-  [class~="lg-gutter-1/2"] > .grid-item,
-  .lg-gutter-half > .grid-item {
-    .to-rem(padding-left, @grid-gutter-half);
-  }
-
-  // Whole gutters
-  .lg-gutter-1,
-  .lg-gutter-whole {
-    .to-rem(margin-left, -@grid-gutter-base);
-  }
-
-  .lg-gutter-1 > .grid-item,
-  .lg-gutter-whole > .grid-item {
-    .to-rem(padding-left, @grid-gutter-base);
-  }
-
-  // Double gutters
-  .lg-gutter-2,
-  .lg-gutter-double {
-    .to-rem(margin-left, -@grid-gutter-double);
-  }
-
-  .lg-gutter-2 > .grid-item,
-  .lg-gutter-double > .grid-item {
-    .to-rem(padding-left, @grid-gutter-double);
-  }
-},{
-  // No gutters
-  .xl-gutter-0,
-  .xl-gutter-none {
-    margin-left: 0;
-  }
-
-  .xl-gutter-0 > .grid-item,
-  .xl-gutter-none > .grid-item {
-    padding-left: 0;
-  }
-
-  // 1px gutters
-  .xl-gutter-1px {
-    .to-rem(margin-left, -@grid-gutter-1px);
-  }
-
-  .xl-gutter-1px > .grid-item {
-    .to-rem(padding-left, @grid-gutter-1px);
-  }
-
-  // Half gutters
-  [class~="xl-gutter-1/2"],
-  .xl-gutter-half {
-    .to-rem(margin-left, -@grid-gutter-half);
-  }
-
-  [class~="xl-gutter-1/2"] > .grid-item,
-  .xl-gutter-half > .grid-item {
-    .to-rem(padding-left, @grid-gutter-half);
-  }
-
-  // Whole gutters
-  .xl-gutter-1,
-  .xl-gutter-whole {
-    .to-rem(margin-left, -@grid-gutter-base);
-  }
-
-  .xl-gutter-1 > .grid-item,
-  .xl-gutter-whole > .grid-item {
-    .to-rem(padding-left, @grid-gutter-base);
-  }
-
-  // Double gutters
-  .xl-gutter-2,
-  .xl-gutter-double {
-    .to-rem(margin-left, -@grid-gutter-double);
-  }
-
-  .xl-gutter-2 > .grid-item,
-  .xl-gutter-double > .grid-item {
-    .to-rem(padding-left, @grid-gutter-double);
-  }
-},{
-  // No gutters
-  .xxl-gutter-0,
-  .xxl-gutter-none {
-    margin-left: 0;
-  }
-
-  .xxl-gutter-0 > .grid-item,
-  .xxl-gutter-none > .grid-item {
-    padding-left: 0;
-  }
-
-  // 1px gutters
-  .xxl-gutter-1px {
-    .to-rem(margin-left, -@grid-gutter-1px);
-  }
-
-  .xxl-gutter-1px > .grid-item {
-    .to-rem(padding-left, @grid-gutter-1px);
-  }
-
-  // Half gutters
-  [class~="xxl-gutter-1/2"],
-  .xxl-gutter-half {
-    .to-rem(margin-left, -@grid-gutter-half);
-  }
-
-  [class~="xxl-gutter-1/2"] > .grid-item,
-  .xxl-gutter-half > .grid-item {
-    .to-rem(padding-left, @grid-gutter-half);
-  }
-
-  // Whole gutters
-  .xxl-gutter-1,
-  .xxl-gutter-whole {
-    .to-rem(margin-left, -@grid-gutter-base);
-  }
-
-  .xxl-gutter-1 > .grid-item,
-  .xxl-gutter-whole > .grid-item {
-    .to-rem(padding-left, @grid-gutter-base);
-  }
-
-  // Double gutters
-  .xxl-gutter-2,
-  .xxl-gutter-double {
-    .to-rem(margin-left, -@grid-gutter-double);
-  }
-
-  .xxl-gutter-2 > .grid-item,
-  .xxl-gutter-double > .grid-item {
+  .@{breakpoint-prefix}gutter-2 > .grid-item,
+  .@{breakpoint-prefix}gutter-double > .grid-item {
     .to-rem(padding-left, @grid-gutter-double);
   }
 });

--- a/utilities/display.less
+++ b/utilities/display.less
@@ -17,339 +17,57 @@
 // colg = table-column-group
 //
 
-.dn {
-  display: none !important;
-}
-
-.di {
-  display: inline !important;
-}
-
-.db {
-  display: block !important;
-}
-
-/**
- * 1. Fix Firefox bug where an <img> styled with `max-width: 100%` inside a
- *    parent styled `inline-block` displays at its default size, not 100% of the
- *    parent container.
- */
-
-.dib {
-  display: inline-block !important;
-  max-width: 100% !important; /* 1 */
-}
-
-.dit {
-  display: inline-table !important;
-}
-
-.dt {
-  display: table !important;
-  table-layout: fixed !important;
-  width: 100% !important;
-}
-
-.dtr {
-  display: table-row !important;
-}
-
-.dtrg {
-  display: table-row-group !important;
-}
-
-.dtc {
-  display: table-cell !important;
-}
-
-.dtcol {
-  display: table-column !important;
-}
-
-.dtcolg {
-  display: table-column-group !important;
-}
-
-.screens({
-  .xs-dn {
+.breakpoint-prefixes({
+  .@{breakpoint-prefix}dn {
     display: none !important;
   }
 
-  .xs-di {
+  .@{breakpoint-prefix}di {
     display: inline !important;
   }
 
-  .xs-db {
+  .@{breakpoint-prefix}db {
     display: block !important;
   }
 
-  .xs-dib {
+  /**
+  * 1. Fix Firefox bug where an <img> styled with `max-width: 100%` inside a
+  *    parent styled `inline-block` displays at its default size, not 100% of the
+  *    parent container.
+  */
+
+  .@{breakpoint-prefix}dib {
     display: inline-block !important;
-    max-width: 100% !important;
+    max-width: 100% !important; /* 1 */
   }
 
-  .xs-dit {
+  .@{breakpoint-prefix}dit {
     display: inline-table !important;
   }
 
-  .xs-dt {
+  .@{breakpoint-prefix}dt {
     display: table !important;
     table-layout: fixed !important;
     width: 100% !important;
   }
 
-  .xs-dtr {
+  .@{breakpoint-prefix}dtr {
     display: table-row !important;
   }
 
-  .xs-dtrg {
+  .@{breakpoint-prefix}dtrg {
     display: table-row-group !important;
   }
 
-  .xs-dtc {
+  .@{breakpoint-prefix}dtc {
     display: table-cell !important;
   }
 
-  .xs-dtcol {
+  .@{breakpoint-prefix}dtcol {
     display: table-column !important;
   }
 
-  .xs-dtcolg {
-    display: table-column-group !important;
-  }
-},{
-  .sm-dn {
-    display: none !important;
-  }
-
-  .sm-di {
-    display: inline !important;
-  }
-
-  .sm-db {
-    display: block !important;
-  }
-
-  .sm-dib {
-    display: inline-block !important;
-    max-width: 100% !important;
-  }
-
-  .sm-dit {
-    display: inline-table !important;
-  }
-
-  .sm-dt {
-    display: table !important;
-    table-layout: fixed !important;
-    width: 100% !important;
-  }
-
-  .sm-dtr {
-    display: table-row !important;
-  }
-
-  .sm-dtrg {
-    display: table-row-group !important;
-  }
-
-  .sm-dtc {
-    display: table-cell !important;
-  }
-
-  .sm-dtcol {
-    display: table-column !important;
-  }
-
-  .sm-dtcolg {
-    display: table-column-group !important;
-  }
-},{
-  .md-dn {
-    display: none !important;
-  }
-
-  .md-di {
-    display: inline !important;
-  }
-
-  .md-db {
-    display: block !important;
-  }
-
-  .md-dib {
-    display: inline-block !important;
-    max-width: 100% !important;
-  }
-
-  .md-dit {
-    display: inline-table !important;
-  }
-
-  .md-dt {
-    display: table !important;
-    table-layout: fixed !important;
-    width: 100% !important;
-  }
-
-  .md-dtr {
-    display: table-row !important;
-  }
-
-  .md-dtrg {
-    display: table-row-group !important;
-  }
-
-  .md-dtc {
-    display: table-cell !important;
-  }
-
-  .md-dtcol {
-    display: table-column !important;
-  }
-
-  .md-dtcolg {
-    display: table-column-group !important;
-  }
-},{
-  .lg-dn {
-    display: none !important;
-  }
-
-  .lg-di {
-    display: inline !important;
-  }
-
-  .lg-db {
-    display: block !important;
-  }
-
-  .lg-dib {
-    display: inline-block !important;
-    max-width: 100% !important;
-  }
-
-  .lg-dit {
-    display: inline-table !important;
-  }
-
-  .lg-dt {
-    display: table !important;
-    table-layout: fixed !important;
-    width: 100% !important;
-  }
-
-  .lg-dtr {
-    display: table-row !important;
-  }
-
-  .lg-dtrg {
-    display: table-row-group !important;
-  }
-
-  .lg-dtc {
-    display: table-cell !important;
-  }
-
-  .lg-dtcol {
-    display: table-column !important;
-  }
-
-  .lg-dtcolg {
-    display: table-column-group !important;
-  }
-},{
-  .xl-dn {
-    display: none !important;
-  }
-
-  .xl-di {
-    display: inline !important;
-  }
-
-  .xl-db {
-    display: block !important;
-  }
-
-  .xl-dib {
-    display: inline-block !important;
-    max-width: 100% !important;
-  }
-
-  .xl-dit {
-    display: inline-table !important;
-  }
-
-  .xl-dt {
-    display: table !important;
-    table-layout: fixed !important;
-    width: 100% !important;
-  }
-
-  .xl-dtr {
-    display: table-row !important;
-  }
-
-  .xl-dtrg {
-    display: table-row-group !important;
-  }
-
-  .xl-dtc {
-    display: table-cell !important;
-  }
-
-  .xl-dtcol {
-    display: table-column !important;
-  }
-
-  .xl-dtcolg {
-    display: table-column-group !important;
-  }
-},{
-  .xxl-dn {
-    display: none !important;
-  }
-
-  .xxl-di {
-    display: inline !important;
-  }
-
-  .xxl-db {
-    display: block !important;
-  }
-
-  .xxl-dib {
-    display: inline-block !important;
-    max-width: 100% !important;
-  }
-
-  .xxl-dit {
-    display: inline-table !important;
-  }
-
-  .xxl-dt {
-    display: table !important;
-    table-layout: fixed !important;
-    width: 100% !important;
-  }
-
-  .xxl-dtr {
-    display: table-row !important;
-  }
-
-  .xxl-dtrg {
-    display: table-row-group !important;
-  }
-
-  .xxl-dtc {
-    display: table-cell !important;
-  }
-
-  .xxl-dtcol {
-    display: table-column !important;
-  }
-
-  .xxl-dtcolg {
+  .@{breakpoint-prefix}dtcolg {
     display: table-column-group !important;
   }
 });

--- a/utilities/floats.less
+++ b/utilities/floats.less
@@ -9,88 +9,16 @@
 // n = none
 //
 
-.fl {
-  float: left !important;
-}
-
-.fr {
-  float: right !important;
-}
-
-.fn {
-  float: none !important;
-}
-
-.screens({
-  .xs-fl {
+.breakpoint-prefixes({
+  .@{breakpoint-prefix}fl {
     float: left !important;
   }
 
-  .xs-fr {
+  .@{breakpoint-prefix}fr {
     float: right !important;
   }
 
-  .xs-fn {
-    float: none !important;
-  }
-},{
-  .sm-fl {
-    float: left !important;
-  }
-
-  .sm-fr {
-    float: right !important;
-  }
-
-  .sm-fn {
-    float: none !important;
-  }
-},{
-  .md-fl {
-    float: left !important;
-  }
-
-  .md-fr {
-    float: right !important;
-  }
-
-  .md-fn {
-    float: none !important;
-  }
-},{
-  .lg-fl {
-    float: left !important;
-  }
-
-  .lg-fr {
-    float: right !important;
-  }
-
-  .lg-fn {
-    float: none !important;
-  }
-},{
-  .xl-fl {
-    float: left !important;
-  }
-
-  .xl-fr {
-    float: right !important;
-  }
-
-  .xl-fn {
-    float: none !important;
-  }
-},{
-  .xxl-fl {
-    float: left !important;
-  }
-
-  .xxl-fr {
-    float: right !important;
-  }
-
-  .xxl-fn {
+  .@{breakpoint-prefix}fn {
     float: none !important;
   }
 });

--- a/utilities/font-sizes.less
+++ b/utilities/font-sizes.less
@@ -19,256 +19,40 @@
  * @link http://cbrac.co/1Pd1ZKl
  */
 
-.fz--- {
-  .to-rem(font-size, @font-size-xxx-small, ~"!important");
-}
-
-.fz-- {
-  .to-rem(font-size, @font-size-xx-small, ~"!important");
-}
-
-.fz- {
-  .to-rem(font-size, @font-size-x-small, ~"!important");
-}
-
-.fz {
-  .to-rem(font-size, @font-size, ~"!important");
-}
-
-.fz\+ {
-  .to-rem(font-size, @font-size-x-large, ~"!important");
-}
-
-.fz\+\+ {
-  .to-rem(font-size, @font-size-xx-large, ~"!important");
-}
-
-.fz\+\+\+ {
-  .to-rem(font-size, @font-size-xxx-large, ~"!important");
-}
-
-.fz100 {
-  font-size: @font-size-100 !important;
-}
-
-.fz0 {
-  font-size: 0 !important;
-}
-
-.screens({
-  .xs-fz--- {
+.breakpoint-prefixes({
+  .@{breakpoint-prefix}fz--- {
     .to-rem(font-size, @font-size-xxx-small, ~"!important");
   }
 
-  .xs-fz-- {
+  .@{breakpoint-prefix}fz-- {
     .to-rem(font-size, @font-size-xx-small, ~"!important");
   }
 
-  .xs-fz- {
+  .@{breakpoint-prefix}fz- {
     .to-rem(font-size, @font-size-x-small, ~"!important");
   }
 
-  .xs-fz {
+  .@{breakpoint-prefix}fz {
     .to-rem(font-size, @font-size, ~"!important");
   }
 
-  .xs-fz\+ {
+  .@{breakpoint-prefix}fz\+ {
     .to-rem(font-size, @font-size-x-large, ~"!important");
   }
 
-  .xs-fz\+\+ {
+  .@{breakpoint-prefix}fz\+\+ {
     .to-rem(font-size, @font-size-xx-large, ~"!important");
   }
 
-  .xs-fz\+\+\+ {
+  .@{breakpoint-prefix}fz\+\+\+ {
     .to-rem(font-size, @font-size-xxx-large, ~"!important");
   }
 
-  .xs-fz100 {
+  .@{breakpoint-prefix}fz100 {
     font-size: @font-size-100 !important;
   }
 
-  .xs-fz0 {
-    font-size: 0 !important;
-  }
-},{
-  .sm-fz--- {
-    .to-rem(font-size, @font-size-xxx-small, ~"!important");
-  }
-
-  .sm-fz-- {
-    .to-rem(font-size, @font-size-xx-small, ~"!important");
-  }
-
-  .sm-fz- {
-    .to-rem(font-size, @font-size-x-small, ~"!important");
-  }
-
-  .sm-fz {
-    .to-rem(font-size, @font-size, ~"!important");
-  }
-
-  .sm-fz\+ {
-    .to-rem(font-size, @font-size-x-large, ~"!important");
-  }
-
-  .sm-fz\+\+ {
-    .to-rem(font-size, @font-size-xx-large, ~"!important");
-  }
-
-  .sm-fz\+\+\+ {
-    .to-rem(font-size, @font-size-xxx-large, ~"!important");
-  }
-
-  .sm-fz100 {
-    font-size: @font-size-100 !important;
-  }
-
-  .sm-fz0 {
-    font-size: 0 !important;
-  }
-},{
-  .md-fz--- {
-    .to-rem(font-size, @font-size-xxx-small, ~"!important");
-  }
-
-  .md-fz-- {
-    .to-rem(font-size, @font-size-xx-small, ~"!important");
-  }
-
-  .md-fz- {
-    .to-rem(font-size, @font-size-x-small, ~"!important");
-  }
-
-  .md-fz {
-    .to-rem(font-size, @font-size, ~"!important");
-  }
-
-  .md-fz\+ {
-    .to-rem(font-size, @font-size-x-large, ~"!important");
-  }
-
-  .md-fz\+\+ {
-    .to-rem(font-size, @font-size-xx-large, ~"!important");
-  }
-
-  .md-fz\+\+\+ {
-    .to-rem(font-size, @font-size-xxx-large, ~"!important");
-  }
-
-  .md-fz100 {
-    font-size: @font-size-100 !important;
-  }
-
-  .md-fz0 {
-    font-size: 0 !important;
-  }
-},{
-  .lg-fz--- {
-    .to-rem(font-size, @font-size-xxx-small, ~"!important");
-  }
-
-  .lg-fz-- {
-    .to-rem(font-size, @font-size-xx-small, ~"!important");
-  }
-
-  .lg-fz- {
-    .to-rem(font-size, @font-size-x-small, ~"!important");
-  }
-
-  .lg-fz {
-    .to-rem(font-size, @font-size, ~"!important");
-  }
-
-  .lg-fz\+ {
-    .to-rem(font-size, @font-size-x-large, ~"!important");
-  }
-
-  .lg-fz\+\+ {
-    .to-rem(font-size, @font-size-xx-large, ~"!important");
-  }
-
-  .lg-fz\+\+\+ {
-    .to-rem(font-size, @font-size-xxx-large, ~"!important");
-  }
-
-  .lg-fz100 {
-    font-size: @font-size-100 !important;
-  }
-
-  .lg-fz0 {
-    font-size: 0 !important;
-  }
-},{
-  .xl-fz--- {
-    .to-rem(font-size, @font-size-xxx-small, ~"!important");
-  }
-
-  .xl-fz-- {
-    .to-rem(font-size, @font-size-xx-small, ~"!important");
-  }
-
-  .xl-fz- {
-    .to-rem(font-size, @font-size-x-small, ~"!important");
-  }
-
-  .xl-fz {
-    .to-rem(font-size, @font-size, ~"!important");
-  }
-
-  .xl-fz\+ {
-    .to-rem(font-size, @font-size-x-large, ~"!important");
-  }
-
-  .xl-fz\+\+ {
-    .to-rem(font-size, @font-size-xx-large, ~"!important");
-  }
-
-  .xl-fz\+\+\+ {
-    .to-rem(font-size, @font-size-xxx-large, ~"!important");
-  }
-
-  .xl-fz100 {
-    font-size: @font-size-100 !important;
-  }
-
-  .xl-fz0 {
-    font-size: 0 !important;
-  }
-},{
-  .xxl-fz--- {
-    .to-rem(font-size, @font-size-xxx-small, ~"!important");
-  }
-
-  .xxl-fz-- {
-    .to-rem(font-size, @font-size-xx-small, ~"!important");
-  }
-
-  .xxl-fz- {
-    .to-rem(font-size, @font-size-x-small, ~"!important");
-  }
-
-  .xxl-fz {
-    .to-rem(font-size, @font-size, ~"!important");
-  }
-
-  .xxl-fz\+ {
-    .to-rem(font-size, @font-size-x-large, ~"!important");
-  }
-
-  .xxl-fz\+\+ {
-    .to-rem(font-size, @font-size-xx-large, ~"!important");
-  }
-
-  .xxl-fz\+\+\+ {
-    .to-rem(font-size, @font-size-xxx-large, ~"!important");
-  }
-
-  .xxl-fz100 {
-    font-size: @font-size-100 !important;
-  }
-
-  .xxl-fz0 {
+  .@{breakpoint-prefix}fz0 {
     font-size: 0 !important;
   }
 });

--- a/utilities/margins.less
+++ b/utilities/margins.less
@@ -22,1305 +22,189 @@
  * @link http://cbrac.co/1Pd1ZKl
  */
 
-// Whole
-.m {
-  .to-rem(margin, @spacing-base, ~"!important");
-}
-
-.mt {
-  .to-rem(margin-top, @spacing-base, ~"!important");
-}
-
-.mr {
-  .to-rem(margin-right, @spacing-base, ~"!important");
-}
-
-.mb {
-  .to-rem(margin-bottom, @spacing-base, ~"!important");
-}
-
-.ml {
-  .to-rem(margin-left, @spacing-base, ~"!important");
-}
-
-.mh {
-  .to-rem(margin-right, @spacing-base, ~"!important");
-  .to-rem(margin-left, @spacing-base, ~"!important");
-}
-
-.mv {
-  .to-rem(margin-top, @spacing-base, ~"!important");
-  .to-rem(margin-bottom, @spacing-base, ~"!important");
-}
-
-// Quarter (--)
-.m-- {
-  .to-rem(margin, @spacing-fourth, ~"!important");
-}
-
-.mt-- {
-  .to-rem(margin-top, @spacing-fourth, ~"!important");
-}
-
-.mr-- {
-  .to-rem(margin-right, @spacing-fourth, ~"!important");
-}
-
-.mb-- {
-  .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-}
-
-.ml-- {
-  .to-rem(margin-left, @spacing-fourth, ~"!important");
-}
-
-.mh-- {
-  .to-rem(margin-right, @spacing-fourth, ~"!important");
-  .to-rem(margin-left, @spacing-fourth, ~"!important");
-}
-
-.mv-- {
-  .to-rem(margin-top, @spacing-fourth, ~"!important");
-  .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-}
-
-// Half (-)
-.m- {
-  .to-rem(margin, @spacing-half, ~"!important");
-}
-
-.mt- {
-  .to-rem(margin-top, @spacing-half, ~"!important");
-}
-
-.mr- {
-  .to-rem(margin-right, @spacing-half, ~"!important");
-}
-
-.mb- {
-  .to-rem(margin-bottom, @spacing-half, ~"!important");
-}
-
-.ml- {
-  .to-rem(margin-left, @spacing-half, ~"!important");
-}
-
-.mh- {
-  .to-rem(margin-right, @spacing-half, ~"!important");
-  .to-rem(margin-left, @spacing-half, ~"!important");
-}
-
-.mv- {
-  .to-rem(margin-top, @spacing-half, ~"!important");
-  .to-rem(margin-bottom, @spacing-half, ~"!important");
-}
-
-// Double (+)
-.m\+ {
-  .to-rem(margin, @spacing-double, ~"!important");
-}
-
-.mt\+ {
-  .to-rem(margin-top, @spacing-double, ~"!important");
-}
-
-.mr\+ {
-  .to-rem(margin-right, @spacing-double, ~"!important");
-}
-
-.mb\+ {
-  .to-rem(margin-bottom, @spacing-double, ~"!important");
-}
-
-.ml\+ {
-  .to-rem(margin-left, @spacing-double, ~"!important");
-}
-
-.mh\+ {
-  .to-rem(margin-right, @spacing-double, ~"!important");
-  .to-rem(margin-left, @spacing-double, ~"!important");
-}
-
-.mv\+ {
-  .to-rem(margin-top, @spacing-double, ~"!important");
-  .to-rem(margin-bottom, @spacing-double, ~"!important");
-}
-
-// Quadruple (++)
-.m\+\+ {
-  .to-rem(margin, @spacing-quadruple, ~"!important");
-}
-
-.mt\+\+ {
-  .to-rem(margin-top, @spacing-quadruple, ~"!important");
-}
-
-.mr\+\+ {
-  .to-rem(margin-right, @spacing-quadruple, ~"!important");
-}
-
-.mb\+\+ {
-  .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-}
-
-.ml\+\+ {
-  .to-rem(margin-left, @spacing-quadruple, ~"!important");
-}
-
-.mh\+\+ {
-  .to-rem(margin-right, @spacing-quadruple, ~"!important");
-  .to-rem(margin-left, @spacing-quadruple, ~"!important");
-}
-
-.mv\+\+ {
-  .to-rem(margin-top, @spacing-quadruple, ~"!important");
-  .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-}
-
-// None (0)
-.m0 {
-  .to-rem(margin, @spacing-none, ~"!important");
-}
-
-.mt0 {
-  .to-rem(margin-top, @spacing-none, ~"!important");
-}
-
-.mr0 {
-  .to-rem(margin-right, @spacing-none, ~"!important");
-}
-
-.mb0 {
-  .to-rem(margin-bottom, @spacing-none, ~"!important");
-}
-
-.ml0 {
-  .to-rem(margin-left, @spacing-none, ~"!important");
-}
-
-.mh0 {
-  .to-rem(margin-right, @spacing-none, ~"!important");
-  .to-rem(margin-left, @spacing-none, ~"!important");
-}
-
-.mv0 {
-  .to-rem(margin-top, @spacing-none, ~"!important");
-  .to-rem(margin-bottom, @spacing-none, ~"!important");
-}
-
-.screens({
+.breakpoint-prefixes({
   // Whole
-  .xs-m {
+  .@{breakpoint-prefix}m {
     .to-rem(margin, @spacing-base, ~"!important");
   }
 
-  .xs-mt {
+  .@{breakpoint-prefix}mt {
     .to-rem(margin-top, @spacing-base, ~"!important");
   }
 
-  .xs-mr {
+  .@{breakpoint-prefix}mr {
     .to-rem(margin-right, @spacing-base, ~"!important");
   }
 
-  .xs-mb {
+  .@{breakpoint-prefix}mb {
     .to-rem(margin-bottom, @spacing-base, ~"!important");
   }
 
-  .xs-ml {
+  .@{breakpoint-prefix}ml {
     .to-rem(margin-left, @spacing-base, ~"!important");
   }
 
-  .xs-mh {
+  .@{breakpoint-prefix}mh {
     .to-rem(margin-right, @spacing-base, ~"!important");
     .to-rem(margin-left, @spacing-base, ~"!important");
   }
 
-  .xs-mv {
+  .@{breakpoint-prefix}mv {
     .to-rem(margin-top, @spacing-base, ~"!important");
     .to-rem(margin-bottom, @spacing-base, ~"!important");
   }
 
   // Quarter (--)
-  .xs-m-- {
+  .@{breakpoint-prefix}m-- {
     .to-rem(margin, @spacing-fourth, ~"!important");
   }
 
-  .xs-mt-- {
+  .@{breakpoint-prefix}mt-- {
     .to-rem(margin-top, @spacing-fourth, ~"!important");
   }
 
-  .xs-mr-- {
+  .@{breakpoint-prefix}mr-- {
     .to-rem(margin-right, @spacing-fourth, ~"!important");
   }
 
-  .xs-mb-- {
+  .@{breakpoint-prefix}mb-- {
     .to-rem(margin-bottom, @spacing-fourth, ~"!important");
   }
 
-  .xs-ml-- {
+  .@{breakpoint-prefix}ml-- {
     .to-rem(margin-left, @spacing-fourth, ~"!important");
   }
 
-  .xs-mh-- {
+  .@{breakpoint-prefix}mh-- {
     .to-rem(margin-right, @spacing-fourth, ~"!important");
     .to-rem(margin-left, @spacing-fourth, ~"!important");
   }
 
-  .xs-mv-- {
+  .@{breakpoint-prefix}mv-- {
     .to-rem(margin-top, @spacing-fourth, ~"!important");
     .to-rem(margin-bottom, @spacing-fourth, ~"!important");
   }
 
   // Half (-)
-  .xs-m- {
+  .@{breakpoint-prefix}m- {
     .to-rem(margin, @spacing-half, ~"!important");
   }
 
-  .xs-mt- {
+  .@{breakpoint-prefix}mt- {
     .to-rem(margin-top, @spacing-half, ~"!important");
   }
 
-  .xs-mr- {
+  .@{breakpoint-prefix}mr- {
     .to-rem(margin-right, @spacing-half, ~"!important");
   }
 
-  .xs-mb- {
+  .@{breakpoint-prefix}mb- {
     .to-rem(margin-bottom, @spacing-half, ~"!important");
   }
 
-  .xs-ml- {
+  .@{breakpoint-prefix}ml- {
     .to-rem(margin-left, @spacing-half, ~"!important");
   }
 
-  .xs-mh- {
+  .@{breakpoint-prefix}mh- {
     .to-rem(margin-right, @spacing-half, ~"!important");
     .to-rem(margin-left, @spacing-half, ~"!important");
   }
 
-  .xs-mv- {
+  .@{breakpoint-prefix}mv- {
     .to-rem(margin-top, @spacing-half, ~"!important");
     .to-rem(margin-bottom, @spacing-half, ~"!important");
   }
 
   // Double (+)
-  .xs-m\+ {
+  .@{breakpoint-prefix}m\+ {
     .to-rem(margin, @spacing-double, ~"!important");
   }
 
-  .xs-mt\+ {
+  .@{breakpoint-prefix}mt\+ {
     .to-rem(margin-top, @spacing-double, ~"!important");
   }
 
-  .xs-mr\+ {
+  .@{breakpoint-prefix}mr\+ {
     .to-rem(margin-right, @spacing-double, ~"!important");
   }
 
-  .xs-mb\+ {
+  .@{breakpoint-prefix}mb\+ {
     .to-rem(margin-bottom, @spacing-double, ~"!important");
   }
 
-  .xs-ml\+ {
+  .@{breakpoint-prefix}ml\+ {
     .to-rem(margin-left, @spacing-double, ~"!important");
   }
 
-  .xs-mh\+ {
+  .@{breakpoint-prefix}mh\+ {
     .to-rem(margin-right, @spacing-double, ~"!important");
     .to-rem(margin-left, @spacing-double, ~"!important");
   }
 
-  .xs-mv\+ {
+  .@{breakpoint-prefix}mv\+ {
     .to-rem(margin-top, @spacing-double, ~"!important");
     .to-rem(margin-bottom, @spacing-double, ~"!important");
   }
 
   // Quadruple (++)
-  .xs-m\+\+ {
+  .@{breakpoint-prefix}m\+\+ {
     .to-rem(margin, @spacing-quadruple, ~"!important");
   }
 
-  .xs-mt\+\+ {
+  .@{breakpoint-prefix}mt\+\+ {
     .to-rem(margin-top, @spacing-quadruple, ~"!important");
   }
 
-  .xs-mr\+\+ {
+  .@{breakpoint-prefix}mr\+\+ {
     .to-rem(margin-right, @spacing-quadruple, ~"!important");
   }
 
-  .xs-mb\+\+ {
+  .@{breakpoint-prefix}mb\+\+ {
     .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
   }
 
-  .xs-ml\+\+ {
+  .@{breakpoint-prefix}ml\+\+ {
     .to-rem(margin-left, @spacing-quadruple, ~"!important");
   }
 
-  .xs-mh\+\+ {
+  .@{breakpoint-prefix}mh\+\+ {
     .to-rem(margin-right, @spacing-quadruple, ~"!important");
     .to-rem(margin-left, @spacing-quadruple, ~"!important");
   }
 
-  .xs-mv\+\+ {
+  .@{breakpoint-prefix}mv\+\+ {
     .to-rem(margin-top, @spacing-quadruple, ~"!important");
     .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
   }
 
   // None (0)
-  .xs-m0 {
+  .@{breakpoint-prefix}m0 {
     .to-rem(margin, @spacing-none, ~"!important");
   }
 
-  .xs-mt0 {
+  .@{breakpoint-prefix}mt0 {
     .to-rem(margin-top, @spacing-none, ~"!important");
   }
 
-  .xs-mr0 {
+  .@{breakpoint-prefix}mr0 {
     .to-rem(margin-right, @spacing-none, ~"!important");
   }
 
-  .xs-mb0 {
+  .@{breakpoint-prefix}mb0 {
     .to-rem(margin-bottom, @spacing-none, ~"!important");
   }
 
-  .xs-ml0 {
+  .@{breakpoint-prefix}ml0 {
     .to-rem(margin-left, @spacing-none, ~"!important");
   }
 
-  .xs-mh0 {
+  .@{breakpoint-prefix}mh0 {
     .to-rem(margin-right, @spacing-none, ~"!important");
     .to-rem(margin-left, @spacing-none, ~"!important");
   }
 
-  .xs-mv0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .sm-m {
-    .to-rem(margin, @spacing-base, ~"!important");
-  }
-
-  .sm-mt {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-  }
-
-  .sm-mr {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-  }
-
-  .sm-mb {
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  .sm-ml {
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .sm-mh {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .sm-mv {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .sm-m-- {
-    .to-rem(margin, @spacing-fourth, ~"!important");
-  }
-
-  .sm-mt-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-  }
-
-  .sm-mr-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-  }
-
-  .sm-mb-- {
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .sm-ml-- {
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .sm-mh-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .sm-mv-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .sm-m- {
-    .to-rem(margin, @spacing-half, ~"!important");
-  }
-
-  .sm-mt- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-  }
-
-  .sm-mr- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-  }
-
-  .sm-mb- {
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  .sm-ml- {
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .sm-mh- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .sm-mv- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .sm-m\+ {
-    .to-rem(margin, @spacing-double, ~"!important");
-  }
-
-  .sm-mt\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-  }
-
-  .sm-mr\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-  }
-
-  .sm-mb\+ {
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  .sm-ml\+ {
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .sm-mh\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .sm-mv\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .sm-m\+\+ {
-    .to-rem(margin, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-mt\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-mr\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-mb\+\+ {
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-ml\+\+ {
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-mh\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-mv\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .sm-m0 {
-    .to-rem(margin, @spacing-none, ~"!important");
-  }
-
-  .sm-mt0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-  }
-
-  .sm-mr0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-  }
-
-  .sm-mb0 {
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-
-  .sm-ml0 {
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .sm-mh0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .sm-mv0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .md-m {
-    .to-rem(margin, @spacing-base, ~"!important");
-  }
-
-  .md-mt {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-  }
-
-  .md-mr {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-  }
-
-  .md-mb {
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  .md-ml {
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .md-mh {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .md-mv {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .md-m-- {
-    .to-rem(margin, @spacing-fourth, ~"!important");
-  }
-
-  .md-mt-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-  }
-
-  .md-mr-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-  }
-
-  .md-mb-- {
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .md-ml-- {
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .md-mh-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .md-mv-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .md-m- {
-    .to-rem(margin, @spacing-half, ~"!important");
-  }
-
-  .md-mt- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-  }
-
-  .md-mr- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-  }
-
-  .md-mb- {
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  .md-ml- {
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .md-mh- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .md-mv- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .md-m\+ {
-    .to-rem(margin, @spacing-double, ~"!important");
-  }
-
-  .md-mt\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-  }
-
-  .md-mr\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-  }
-
-  .md-mb\+ {
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  .md-ml\+ {
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .md-mh\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .md-mv\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .md-m\+\+ {
-    .to-rem(margin, @spacing-quadruple, ~"!important");
-  }
-
-  .md-mt\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-  }
-
-  .md-mr\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-  }
-
-  .md-mb\+\+ {
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .md-ml\+\+ {
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .md-mh\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .md-mv\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .md-m0 {
-    .to-rem(margin, @spacing-none, ~"!important");
-  }
-
-  .md-mt0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-  }
-
-  .md-mr0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-  }
-
-  .md-mb0 {
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-
-  .md-ml0 {
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .md-mh0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .md-mv0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .lg-m {
-    .to-rem(margin, @spacing-base, ~"!important");
-  }
-
-  .lg-mt {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-  }
-
-  .lg-mr {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-  }
-
-  .lg-mb {
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  .lg-ml {
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .lg-mh {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .lg-mv {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .lg-m-- {
-    .to-rem(margin, @spacing-fourth, ~"!important");
-  }
-
-  .lg-mt-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-  }
-
-  .lg-mr-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-  }
-
-  .lg-mb-- {
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .lg-ml-- {
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .lg-mh-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .lg-mv-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .lg-m- {
-    .to-rem(margin, @spacing-half, ~"!important");
-  }
-
-  .lg-mt- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-  }
-
-  .lg-mr- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-  }
-
-  .lg-mb- {
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  .lg-ml- {
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .lg-mh- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .lg-mv- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .lg-m\+ {
-    .to-rem(margin, @spacing-double, ~"!important");
-  }
-
-  .lg-mt\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-  }
-
-  .lg-mr\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-  }
-
-  .lg-mb\+ {
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  .lg-ml\+ {
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .lg-mh\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .lg-mv\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .lg-m\+\+ {
-    .to-rem(margin, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-mt\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-mr\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-mb\+\+ {
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-ml\+\+ {
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-mh\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-mv\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .lg-m0 {
-    .to-rem(margin, @spacing-none, ~"!important");
-  }
-
-  .lg-mt0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-  }
-
-  .lg-mr0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-  }
-
-  .lg-mb0 {
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-
-  .lg-ml0 {
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .lg-mh0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .lg-mv0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .xl-m {
-    .to-rem(margin, @spacing-base, ~"!important");
-  }
-
-  .xl-mt {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-  }
-
-  .xl-mr {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-  }
-
-  .xl-mb {
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  .xl-ml {
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .xl-mh {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .xl-mv {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .xl-m-- {
-    .to-rem(margin, @spacing-fourth, ~"!important");
-  }
-
-  .xl-mt-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-  }
-
-  .xl-mr-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-  }
-
-  .xl-mb-- {
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .xl-ml-- {
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .xl-mh-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .xl-mv-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .xl-m- {
-    .to-rem(margin, @spacing-half, ~"!important");
-  }
-
-  .xl-mt- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-  }
-
-  .xl-mr- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-  }
-
-  .xl-mb- {
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  .xl-ml- {
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .xl-mh- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .xl-mv- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .xl-m\+ {
-    .to-rem(margin, @spacing-double, ~"!important");
-  }
-
-  .xl-mt\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-  }
-
-  .xl-mr\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-  }
-
-  .xl-mb\+ {
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  .xl-ml\+ {
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .xl-mh\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .xl-mv\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .xl-m\+\+ {
-    .to-rem(margin, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-mt\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-mr\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-mb\+\+ {
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-ml\+\+ {
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-mh\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-mv\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .xl-m0 {
-    .to-rem(margin, @spacing-none, ~"!important");
-  }
-
-  .xl-mt0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-  }
-
-  .xl-mr0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-  }
-
-  .xl-mb0 {
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-
-  .xl-ml0 {
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .xl-mh0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .xl-mv0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .xxl-m {
-    .to-rem(margin, @spacing-base, ~"!important");
-  }
-
-  .xxl-mt {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-  }
-
-  .xxl-mr {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-  }
-
-  .xxl-mb {
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  .xxl-ml {
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .xxl-mh {
-    .to-rem(margin-right, @spacing-base, ~"!important");
-    .to-rem(margin-left, @spacing-base, ~"!important");
-  }
-
-  .xxl-mv {
-    .to-rem(margin-top, @spacing-base, ~"!important");
-    .to-rem(margin-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .xxl-m-- {
-    .to-rem(margin, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-mt-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-mr-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-mb-- {
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-ml-- {
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-mh-- {
-    .to-rem(margin-right, @spacing-fourth, ~"!important");
-    .to-rem(margin-left, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-mv-- {
-    .to-rem(margin-top, @spacing-fourth, ~"!important");
-    .to-rem(margin-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .xxl-m- {
-    .to-rem(margin, @spacing-half, ~"!important");
-  }
-
-  .xxl-mt- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-  }
-
-  .xxl-mr- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-  }
-
-  .xxl-mb- {
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  .xxl-ml- {
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .xxl-mh- {
-    .to-rem(margin-right, @spacing-half, ~"!important");
-    .to-rem(margin-left, @spacing-half, ~"!important");
-  }
-
-  .xxl-mv- {
-    .to-rem(margin-top, @spacing-half, ~"!important");
-    .to-rem(margin-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .xxl-m\+ {
-    .to-rem(margin, @spacing-double, ~"!important");
-  }
-
-  .xxl-mt\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-  }
-
-  .xxl-mr\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-  }
-
-  .xxl-mb\+ {
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  .xxl-ml\+ {
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .xxl-mh\+ {
-    .to-rem(margin-right, @spacing-double, ~"!important");
-    .to-rem(margin-left, @spacing-double, ~"!important");
-  }
-
-  .xxl-mv\+ {
-    .to-rem(margin-top, @spacing-double, ~"!important");
-    .to-rem(margin-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .xxl-m\+\+ {
-    .to-rem(margin, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-mt\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-mr\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-mb\+\+ {
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-ml\+\+ {
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-mh\+\+ {
-    .to-rem(margin-right, @spacing-quadruple, ~"!important");
-    .to-rem(margin-left, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-mv\+\+ {
-    .to-rem(margin-top, @spacing-quadruple, ~"!important");
-    .to-rem(margin-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .xxl-m0 {
-    .to-rem(margin, @spacing-none, ~"!important");
-  }
-
-  .xxl-mt0 {
-    .to-rem(margin-top, @spacing-none, ~"!important");
-  }
-
-  .xxl-mr0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-  }
-
-  .xxl-mb0 {
-    .to-rem(margin-bottom, @spacing-none, ~"!important");
-  }
-
-  .xxl-ml0 {
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .xxl-mh0 {
-    .to-rem(margin-right, @spacing-none, ~"!important");
-    .to-rem(margin-left, @spacing-none, ~"!important");
-  }
-
-  .xxl-mv0 {
+  .@{breakpoint-prefix}mv0 {
     .to-rem(margin-top, @spacing-none, ~"!important");
     .to-rem(margin-bottom, @spacing-none, ~"!important");
   }

--- a/utilities/paddings.less
+++ b/utilities/paddings.less
@@ -15,7 +15,7 @@
 // +  = double
 // ++ = quadruple
 // 0  = none
-// 
+//
 
 /**
  * Hat tip to @csswizardry for the +/- technique.
@@ -23,1305 +23,189 @@
  * @link http://cbrac.co/1Pd1ZKl
  */
 
-// Whole
-.p {
-  .to-rem(padding, @spacing-base, ~"!important");
-}
-
-.pt {
-  .to-rem(padding-top, @spacing-base, ~"!important");
-}
-
-.pr {
-  .to-rem(padding-right, @spacing-base, ~"!important");
-}
-
-.pb {
-  .to-rem(padding-bottom, @spacing-base, ~"!important");
-}
-
-.pl {
-  .to-rem(padding-left, @spacing-base, ~"!important");
-}
-
-.ph {
-  .to-rem(padding-right, @spacing-base, ~"!important");
-  .to-rem(padding-left, @spacing-base, ~"!important");
-}
-
-.pv {
-  .to-rem(padding-top, @spacing-base, ~"!important");
-  .to-rem(padding-bottom, @spacing-base, ~"!important");
-}
-
-// Quarter (--)
-.p-- {
-  .to-rem(padding, @spacing-fourth, ~"!important");
-}
-
-.pt-- {
-  .to-rem(padding-top, @spacing-fourth, ~"!important");
-}
-
-.pr-- {
-  .to-rem(padding-right, @spacing-fourth, ~"!important");
-}
-
-.pb-- {
-  .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-}
-
-.pl-- {
-  .to-rem(padding-left, @spacing-fourth, ~"!important");
-}
-
-.ph-- {
-  .to-rem(padding-right, @spacing-fourth, ~"!important");
-  .to-rem(padding-left, @spacing-fourth, ~"!important");
-}
-
-.pv-- {
-  .to-rem(padding-top, @spacing-fourth, ~"!important");
-  .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-}
-
-// Half (-)
-.p- {
-  .to-rem(padding, @spacing-half, ~"!important");
-}
-
-.pt- {
-  .to-rem(padding-top, @spacing-half, ~"!important");
-}
-
-.pr- {
-  .to-rem(padding-right, @spacing-half, ~"!important");
-}
-
-.pb- {
-  .to-rem(padding-bottom, @spacing-half, ~"!important");
-}
-
-.pl- {
-  .to-rem(padding-left, @spacing-half, ~"!important");
-}
-
-.ph- {
-  .to-rem(padding-right, @spacing-half, ~"!important");
-  .to-rem(padding-left, @spacing-half, ~"!important");
-}
-
-.pv- {
-  .to-rem(padding-top, @spacing-half, ~"!important");
-  .to-rem(padding-bottom, @spacing-half, ~"!important");
-}
-
-// Double (+)
-.p\+ {
-  .to-rem(padding, @spacing-double, ~"!important");
-}
-
-.pt\+ {
-  .to-rem(padding-top, @spacing-double, ~"!important");
-}
-
-.pr\+ {
-  .to-rem(padding-right, @spacing-double, ~"!important");
-}
-
-.pb\+ {
-  .to-rem(padding-bottom, @spacing-double, ~"!important");
-}
-
-.pl\+ {
-  .to-rem(padding-left, @spacing-double, ~"!important");
-}
-
-.ph\+ {
-  .to-rem(padding-right, @spacing-double, ~"!important");
-  .to-rem(padding-left, @spacing-double, ~"!important");
-}
-
-.pv\+ {
-  .to-rem(padding-top, @spacing-double, ~"!important");
-  .to-rem(padding-bottom, @spacing-double, ~"!important");
-}
-
-// Quadruple (++)
-.p\+\+ {
-  .to-rem(padding, @spacing-quadruple, ~"!important");
-}
-
-.pt\+\+ {
-  .to-rem(padding-top, @spacing-quadruple, ~"!important");
-}
-
-.pr\+\+ {
-  .to-rem(padding-right, @spacing-quadruple, ~"!important");
-}
-
-.pb\+\+ {
-  .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-}
-
-.pl\+\+ {
-  .to-rem(padding-left, @spacing-quadruple, ~"!important");
-}
-
-.ph\+\+ {
-  .to-rem(padding-right, @spacing-quadruple, ~"!important");
-  .to-rem(padding-left, @spacing-quadruple, ~"!important");
-}
-
-.pv\+\+ {
-  .to-rem(padding-top, @spacing-quadruple, ~"!important");
-  .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-}
-
-// None (0)
-.p0 {
-  .to-rem(padding, @spacing-none, ~"!important");
-}
-
-.pt0 {
-  .to-rem(padding-top, @spacing-none, ~"!important");
-}
-
-.pr0 {
-  .to-rem(padding-right, @spacing-none, ~"!important");
-}
-
-.pb0 {
-  .to-rem(padding-bottom, @spacing-none, ~"!important");
-}
-
-.pl0 {
-  .to-rem(padding-left, @spacing-none, ~"!important");
-}
-
-.ph0 {
-  .to-rem(padding-right, @spacing-none, ~"!important");
-  .to-rem(padding-left, @spacing-none, ~"!important");
-}
-
-.pv0 {
-  .to-rem(padding-top, @spacing-none, ~"!important");
-  .to-rem(padding-bottom, @spacing-none, ~"!important");
-}
-
-.screens({
+.breakpoint-prefixes({
   // Whole
-  .xs-p {
+  .@{breakpoint-prefix}p {
     .to-rem(padding, @spacing-base, ~"!important");
   }
 
-  .xs-pt {
+  .@{breakpoint-prefix}pt {
     .to-rem(padding-top, @spacing-base, ~"!important");
   }
 
-  .xs-pr {
+  .@{breakpoint-prefix}pr {
     .to-rem(padding-right, @spacing-base, ~"!important");
   }
 
-  .xs-pb {
+  .@{breakpoint-prefix}pb {
     .to-rem(padding-bottom, @spacing-base, ~"!important");
   }
 
-  .xs-pl {
+  .@{breakpoint-prefix}pl {
     .to-rem(padding-left, @spacing-base, ~"!important");
   }
 
-  .xs-ph {
+  .@{breakpoint-prefix}ph {
     .to-rem(padding-right, @spacing-base, ~"!important");
     .to-rem(padding-left, @spacing-base, ~"!important");
   }
 
-  .xs-pv {
+  .@{breakpoint-prefix}pv {
     .to-rem(padding-top, @spacing-base, ~"!important");
     .to-rem(padding-bottom, @spacing-base, ~"!important");
   }
 
   // Quarter (--)
-  .xs-p-- {
+  .@{breakpoint-prefix}p-- {
     .to-rem(padding, @spacing-fourth, ~"!important");
   }
 
-  .xs-pt-- {
+  .@{breakpoint-prefix}pt-- {
     .to-rem(padding-top, @spacing-fourth, ~"!important");
   }
 
-  .xs-pr-- {
+  .@{breakpoint-prefix}pr-- {
     .to-rem(padding-right, @spacing-fourth, ~"!important");
   }
 
-  .xs-pb-- {
+  .@{breakpoint-prefix}pb-- {
     .to-rem(padding-bottom, @spacing-fourth, ~"!important");
   }
 
-  .xs-pl-- {
+  .@{breakpoint-prefix}pl-- {
     .to-rem(padding-left, @spacing-fourth, ~"!important");
   }
 
-  .xs-ph-- {
+  .@{breakpoint-prefix}ph-- {
     .to-rem(padding-right, @spacing-fourth, ~"!important");
     .to-rem(padding-left, @spacing-fourth, ~"!important");
   }
 
-  .xs-pv-- {
+  .@{breakpoint-prefix}pv-- {
     .to-rem(padding-top, @spacing-fourth, ~"!important");
     .to-rem(padding-bottom, @spacing-fourth, ~"!important");
   }
 
   // Half (-)
-  .xs-p- {
+  .@{breakpoint-prefix}p- {
     .to-rem(padding, @spacing-half, ~"!important");
   }
 
-  .xs-pt- {
+  .@{breakpoint-prefix}pt- {
     .to-rem(padding-top, @spacing-half, ~"!important");
   }
 
-  .xs-pr- {
+  .@{breakpoint-prefix}pr- {
     .to-rem(padding-right, @spacing-half, ~"!important");
   }
 
-  .xs-pb- {
+  .@{breakpoint-prefix}pb- {
     .to-rem(padding-bottom, @spacing-half, ~"!important");
   }
 
-  .xs-pl- {
+  .@{breakpoint-prefix}pl- {
     .to-rem(padding-left, @spacing-half, ~"!important");
   }
 
-  .xs-ph- {
+  .@{breakpoint-prefix}ph- {
     .to-rem(padding-right, @spacing-half, ~"!important");
     .to-rem(padding-left, @spacing-half, ~"!important");
   }
 
-  .xs-pv- {
+  .@{breakpoint-prefix}pv- {
     .to-rem(padding-top, @spacing-half, ~"!important");
     .to-rem(padding-bottom, @spacing-half, ~"!important");
   }
 
   // Double (+)
-  .xs-p\+ {
+  .@{breakpoint-prefix}p\+ {
     .to-rem(padding, @spacing-double, ~"!important");
   }
 
-  .xs-pt\+ {
+  .@{breakpoint-prefix}pt\+ {
     .to-rem(padding-top, @spacing-double, ~"!important");
   }
 
-  .xs-pr\+ {
+  .@{breakpoint-prefix}pr\+ {
     .to-rem(padding-right, @spacing-double, ~"!important");
   }
 
-  .xs-pb\+ {
+  .@{breakpoint-prefix}pb\+ {
     .to-rem(padding-bottom, @spacing-double, ~"!important");
   }
 
-  .xs-pl\+ {
+  .@{breakpoint-prefix}pl\+ {
     .to-rem(padding-left, @spacing-double, ~"!important");
   }
 
-  .xs-ph\+ {
+  .@{breakpoint-prefix}ph\+ {
     .to-rem(padding-right, @spacing-double, ~"!important");
     .to-rem(padding-left, @spacing-double, ~"!important");
   }
 
-  .xs-pv\+ {
+  .@{breakpoint-prefix}pv\+ {
     .to-rem(padding-top, @spacing-double, ~"!important");
     .to-rem(padding-bottom, @spacing-double, ~"!important");
   }
 
   // Quadruple (++)
-  .xs-p\+\+ {
+  .@{breakpoint-prefix}p\+\+ {
     .to-rem(padding, @spacing-quadruple, ~"!important");
   }
 
-  .xs-pt\+\+ {
+  .@{breakpoint-prefix}pt\+\+ {
     .to-rem(padding-top, @spacing-quadruple, ~"!important");
   }
 
-  .xs-pr\+\+ {
+  .@{breakpoint-prefix}pr\+\+ {
     .to-rem(padding-right, @spacing-quadruple, ~"!important");
   }
 
-  .xs-pb\+\+ {
+  .@{breakpoint-prefix}pb\+\+ {
     .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
   }
 
-  .xs-pl\+\+ {
+  .@{breakpoint-prefix}pl\+\+ {
     .to-rem(padding-left, @spacing-quadruple, ~"!important");
   }
 
-  .xs-ph\+\+ {
+  .@{breakpoint-prefix}ph\+\+ {
     .to-rem(padding-right, @spacing-quadruple, ~"!important");
     .to-rem(padding-left, @spacing-quadruple, ~"!important");
   }
 
-  .xs-pv\+\+ {
+  .@{breakpoint-prefix}pv\+\+ {
     .to-rem(padding-top, @spacing-quadruple, ~"!important");
     .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
   }
 
   // None (0)
-  .xs-p0 {
+  .@{breakpoint-prefix}p0 {
     .to-rem(padding, @spacing-none, ~"!important");
   }
 
-  .xs-pt0 {
+  .@{breakpoint-prefix}pt0 {
     .to-rem(padding-top, @spacing-none, ~"!important");
   }
 
-  .xs-pr0 {
+  .@{breakpoint-prefix}pr0 {
     .to-rem(padding-right, @spacing-none, ~"!important");
   }
 
-  .xs-pb0 {
+  .@{breakpoint-prefix}pb0 {
     .to-rem(padding-bottom, @spacing-none, ~"!important");
   }
 
-  .xs-pl0 {
+  .@{breakpoint-prefix}pl0 {
     .to-rem(padding-left, @spacing-none, ~"!important");
   }
 
-  .xs-ph0 {
+  .@{breakpoint-prefix}ph0 {
     .to-rem(padding-right, @spacing-none, ~"!important");
     .to-rem(padding-left, @spacing-none, ~"!important");
   }
 
-  .xs-pv0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .sm-p {
-    .to-rem(padding, @spacing-base, ~"!important");
-  }
-
-  .sm-pt {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-  }
-
-  .sm-pr {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-  }
-
-  .sm-pb {
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  .sm-pl {
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .sm-ph {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .sm-pv {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .sm-p-- {
-    .to-rem(padding, @spacing-fourth, ~"!important");
-  }
-
-  .sm-pt-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-  }
-
-  .sm-pr-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-  }
-
-  .sm-pb-- {
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .sm-pl-- {
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .sm-ph-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .sm-pv-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .sm-p- {
-    .to-rem(padding, @spacing-half, ~"!important");
-  }
-
-  .sm-pt- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-  }
-
-  .sm-pr- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-  }
-
-  .sm-pb- {
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  .sm-pl- {
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .sm-ph- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .sm-pv- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .sm-p\+ {
-    .to-rem(padding, @spacing-double, ~"!important");
-  }
-
-  .sm-pt\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-  }
-
-  .sm-pr\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-  }
-
-  .sm-pb\+ {
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  .sm-pl\+ {
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .sm-ph\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .sm-pv\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .sm-p\+\+ {
-    .to-rem(padding, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-pt\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-pr\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-pb\+\+ {
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-pl\+\+ {
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-ph\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .sm-pv\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .sm-p0 {
-    .to-rem(padding, @spacing-none, ~"!important");
-  }
-
-  .sm-pt0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-  }
-
-  .sm-pr0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-  }
-
-  .sm-pb0 {
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-
-  .sm-pl0 {
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .sm-ph0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .sm-pv0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .md-p {
-    .to-rem(padding, @spacing-base, ~"!important");
-  }
-
-  .md-pt {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-  }
-
-  .md-pr {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-  }
-
-  .md-pb {
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  .md-pl {
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .md-ph {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .md-pv {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .md-p-- {
-    .to-rem(padding, @spacing-fourth, ~"!important");
-  }
-
-  .md-pt-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-  }
-
-  .md-pr-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-  }
-
-  .md-pb-- {
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .md-pl-- {
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .md-ph-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .md-pv-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .md-p- {
-    .to-rem(padding, @spacing-half, ~"!important");
-  }
-
-  .md-pt- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-  }
-
-  .md-pr- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-  }
-
-  .md-pb- {
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  .md-pl- {
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .md-ph- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .md-pv- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .md-p\+ {
-    .to-rem(padding, @spacing-double, ~"!important");
-  }
-
-  .md-pt\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-  }
-
-  .md-pr\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-  }
-
-  .md-pb\+ {
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  .md-pl\+ {
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .md-ph\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .md-pv\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .md-p\+\+ {
-    .to-rem(padding, @spacing-quadruple, ~"!important");
-  }
-
-  .md-pt\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-  }
-
-  .md-pr\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-  }
-
-  .md-pb\+\+ {
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .md-pl\+\+ {
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .md-ph\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .md-pv\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .md-p0 {
-    .to-rem(padding, @spacing-none, ~"!important");
-  }
-
-  .md-pt0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-  }
-
-  .md-pr0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-  }
-
-  .md-pb0 {
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-
-  .md-pl0 {
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .md-ph0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .md-pv0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .lg-p {
-    .to-rem(padding, @spacing-base, ~"!important");
-  }
-
-  .lg-pt {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-  }
-
-  .lg-pr {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-  }
-
-  .lg-pb {
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  .lg-pl {
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .lg-ph {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .lg-pv {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .lg-p-- {
-    .to-rem(padding, @spacing-fourth, ~"!important");
-  }
-
-  .lg-pt-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-  }
-
-  .lg-pr-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-  }
-
-  .lg-pb-- {
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .lg-pl-- {
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .lg-ph-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .lg-pv-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .lg-p- {
-    .to-rem(padding, @spacing-half, ~"!important");
-  }
-
-  .lg-pt- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-  }
-
-  .lg-pr- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-  }
-
-  .lg-pb- {
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  .lg-pl- {
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .lg-ph- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .lg-pv- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .lg-p\+ {
-    .to-rem(padding, @spacing-double, ~"!important");
-  }
-
-  .lg-pt\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-  }
-
-  .lg-pr\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-  }
-
-  .lg-pb\+ {
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  .lg-pl\+ {
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .lg-ph\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .lg-pv\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .lg-p\+\+ {
-    .to-rem(padding, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-pt\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-pr\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-pb\+\+ {
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-pl\+\+ {
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-ph\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .lg-pv\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .lg-p0 {
-    .to-rem(padding, @spacing-none, ~"!important");
-  }
-
-  .lg-pt0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-  }
-
-  .lg-pr0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-  }
-
-  .lg-pb0 {
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-
-  .lg-pl0 {
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .lg-ph0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .lg-pv0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .xl-p {
-    .to-rem(padding, @spacing-base, ~"!important");
-  }
-
-  .xl-pt {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-  }
-
-  .xl-pr {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-  }
-
-  .xl-pb {
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  .xl-pl {
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .xl-ph {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .xl-pv {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .xl-p-- {
-    .to-rem(padding, @spacing-fourth, ~"!important");
-  }
-
-  .xl-pt-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-  }
-
-  .xl-pr-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-  }
-
-  .xl-pb-- {
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .xl-pl-- {
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .xl-ph-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .xl-pv-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .xl-p- {
-    .to-rem(padding, @spacing-half, ~"!important");
-  }
-
-  .xl-pt- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-  }
-
-  .xl-pr- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-  }
-
-  .xl-pb- {
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  .xl-pl- {
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .xl-ph- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .xl-pv- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .xl-p\+ {
-    .to-rem(padding, @spacing-double, ~"!important");
-  }
-
-  .xl-pt\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-  }
-
-  .xl-pr\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-  }
-
-  .xl-pb\+ {
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  .xl-pl\+ {
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .xl-ph\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .xl-pv\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .xl-p\+\+ {
-    .to-rem(padding, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-pt\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-pr\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-pb\+\+ {
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-pl\+\+ {
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-ph\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .xl-pv\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .xl-p0 {
-    .to-rem(padding, @spacing-none, ~"!important");
-  }
-
-  .xl-pt0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-  }
-
-  .xl-pr0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-  }
-
-  .xl-pb0 {
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-
-  .xl-pl0 {
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .xl-ph0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .xl-pv0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-},{
-  // Whole
-  .xxl-p {
-    .to-rem(padding, @spacing-base, ~"!important");
-  }
-
-  .xxl-pt {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-  }
-
-  .xxl-pr {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-  }
-
-  .xxl-pb {
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  .xxl-pl {
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .xxl-ph {
-    .to-rem(padding-right, @spacing-base, ~"!important");
-    .to-rem(padding-left, @spacing-base, ~"!important");
-  }
-
-  .xxl-pv {
-    .to-rem(padding-top, @spacing-base, ~"!important");
-    .to-rem(padding-bottom, @spacing-base, ~"!important");
-  }
-
-  // Quarter (--)
-  .xxl-p-- {
-    .to-rem(padding, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-pt-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-pr-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-pb-- {
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-pl-- {
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-ph-- {
-    .to-rem(padding-right, @spacing-fourth, ~"!important");
-    .to-rem(padding-left, @spacing-fourth, ~"!important");
-  }
-
-  .xxl-pv-- {
-    .to-rem(padding-top, @spacing-fourth, ~"!important");
-    .to-rem(padding-bottom, @spacing-fourth, ~"!important");
-  }
-
-  // Half (-)
-  .xxl-p- {
-    .to-rem(padding, @spacing-half, ~"!important");
-  }
-
-  .xxl-pt- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-  }
-
-  .xxl-pr- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-  }
-
-  .xxl-pb- {
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  .xxl-pl- {
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .xxl-ph- {
-    .to-rem(padding-right, @spacing-half, ~"!important");
-    .to-rem(padding-left, @spacing-half, ~"!important");
-  }
-
-  .xxl-pv- {
-    .to-rem(padding-top, @spacing-half, ~"!important");
-    .to-rem(padding-bottom, @spacing-half, ~"!important");
-  }
-
-  // Double (+)
-  .xxl-p\+ {
-    .to-rem(padding, @spacing-double, ~"!important");
-  }
-
-  .xxl-pt\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-  }
-
-  .xxl-pr\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-  }
-
-  .xxl-pb\+ {
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  .xxl-pl\+ {
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .xxl-ph\+ {
-    .to-rem(padding-right, @spacing-double, ~"!important");
-    .to-rem(padding-left, @spacing-double, ~"!important");
-  }
-
-  .xxl-pv\+ {
-    .to-rem(padding-top, @spacing-double, ~"!important");
-    .to-rem(padding-bottom, @spacing-double, ~"!important");
-  }
-
-  // Quadruple (++)
-  .xxl-p\+\+ {
-    .to-rem(padding, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-pt\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-pr\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-pb\+\+ {
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-pl\+\+ {
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-ph\+\+ {
-    .to-rem(padding-right, @spacing-quadruple, ~"!important");
-    .to-rem(padding-left, @spacing-quadruple, ~"!important");
-  }
-
-  .xxl-pv\+\+ {
-    .to-rem(padding-top, @spacing-quadruple, ~"!important");
-    .to-rem(padding-bottom, @spacing-quadruple, ~"!important");
-  }
-
-  // None (0)
-  .xxl-p0 {
-    .to-rem(padding, @spacing-none, ~"!important");
-  }
-
-  .xxl-pt0 {
-    .to-rem(padding-top, @spacing-none, ~"!important");
-  }
-
-  .xxl-pr0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-  }
-
-  .xxl-pb0 {
-    .to-rem(padding-bottom, @spacing-none, ~"!important");
-  }
-
-  .xxl-pl0 {
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .xxl-ph0 {
-    .to-rem(padding-right, @spacing-none, ~"!important");
-    .to-rem(padding-left, @spacing-none, ~"!important");
-  }
-
-  .xxl-pv0 {
+  .@{breakpoint-prefix}pv0 {
     .to-rem(padding-top, @spacing-none, ~"!important");
     .to-rem(padding-bottom, @spacing-none, ~"!important");
   }

--- a/utilities/positions.less
+++ b/utilities/positions.less
@@ -10,116 +10,20 @@
 // s   = static
 //
 
-.posa {
-  position: absolute !important;
-}
-
-.posf {
-  position: fixed !important;
-}
-
-.posr {
-  position: relative !important;
-}
-
-.poss {
-  position: static !important;
-}
-
-.screens({
-  .xs-posa {
+.breakpoint-prefixes({
+  .@{breakpoint-prefix}posa {
     position: absolute !important;
   }
 
-  .xs-posf {
+  .@{breakpoint-prefix}posf {
     position: fixed !important;
   }
 
-  .xs-posr {
+  .@{breakpoint-prefix}posr {
     position: relative !important;
   }
 
-  .xs-poss {
-    position: static !important;
-  }
-},{
-  .sm-posa {
-    position: absolute !important;
-  }
-
-  .sm-posf {
-    position: fixed !important;
-  }
-
-  .sm-posr {
-    position: relative !important;
-  }
-
-  .sm-poss {
-    position: static !important;
-  }
-},{
-  .md-posa {
-    position: absolute !important;
-  }
-
-  .md-posf {
-    position: fixed !important;
-  }
-
-  .md-posr {
-    position: relative !important;
-  }
-
-  .md-poss {
-    position: static !important;
-  }
-},{
-  .lg-posa {
-    position: absolute !important;
-  }
-
-  .lg-posf {
-    position: fixed !important;
-  }
-
-  .lg-posr {
-    position: relative !important;
-  }
-
-  .lg-poss {
-    position: static !important;
-  }
-},{
-  .xl-posa {
-    position: absolute !important;
-  }
-
-  .xl-posf {
-    position: fixed !important;
-  }
-
-  .xl-posr {
-    position: relative !important;
-  }
-
-  .xl-poss {
-    position: static !important;
-  }
-},{
-  .xxl-posa {
-    position: absolute !important;
-  }
-
-  .xxl-posf {
-    position: fixed !important;
-  }
-
-  .xxl-posr {
-    position: relative !important;
-  }
-
-  .xxl-poss {
+  .@{breakpoint-prefix}poss {
     position: static !important;
   }
 });

--- a/utilities/text-alignment.less
+++ b/utilities/text-alignment.less
@@ -12,116 +12,20 @@
 // j = justify
 //
 
-.tl {
-  text-align: left !important;
-}
-
-.tr {
-  text-align: right !important;
-}
-
-.tc {
-  text-align: center !important;
-}
-
-.tj {
-  text-align: justify !important;
-}
-
-.screens({
-  .xs-tl {
+.breakpoint-prefixes({
+  .@{breakpoint-prefix}tl {
     text-align: left !important;
   }
 
-  .xs-tr {
+  .@{breakpoint-prefix}tr {
     text-align: right !important;
   }
 
-  .xs-tc {
+  .@{breakpoint-prefix}tc {
     text-align: center !important;
   }
 
-  .xs-tj {
-    text-align: justify !important;
-  }
-},{
-  .sm-tl {
-    text-align: left !important;
-  }
-
-  .sm-tr {
-    text-align: right !important;
-  }
-
-  .sm-tc {
-    text-align: center !important;
-  }
-
-  .sm-tj {
-    text-align: justify !important;
-  }
-},{
-  .md-tl {
-    text-align: left !important;
-  }
-
-  .md-tr {
-    text-align: right !important;
-  }
-
-  .md-tc {
-    text-align: center !important;
-  }
-
-  .md-tj {
-    text-align: justify !important;
-  }
-},{
-  .lg-tl {
-    text-align: left !important;
-  }
-
-  .lg-tr {
-    text-align: right !important;
-  }
-
-  .lg-tc {
-    text-align: center !important;
-  }
-
-  .lg-tj {
-    text-align: justify !important;
-  }
-},{
-  .xl-tl {
-    text-align: left !important;
-  }
-
-  .xl-tr {
-    text-align: right !important;
-  }
-
-  .xl-tc {
-    text-align: center !important;
-  }
-
-  .xl-tj {
-    text-align: justify !important;
-  }
-},{
-  .xxl-tl {
-    text-align: left !important;
-  }
-
-  .xxl-tr {
-    text-align: right !important;
-  }
-
-  .xxl-tc {
-    text-align: center !important;
-  }
-
-  .xxl-tj {
+  .@{breakpoint-prefix}tj {
     text-align: justify !important;
   }
 });

--- a/utilities/vertical-alignment.less
+++ b/utilities/vertical-alignment.less
@@ -11,88 +11,16 @@
 // m  = middle
 //
 
-.vat {
-  vertical-align: top !important;
-}
-
-.vab {
-  vertical-align: bottom !important;
-}
-
-.vam {
-  vertical-align: middle !important;
-}
-
-.screens({
-  .xs-vat {
+.breakpoint-prefixes({
+  .@{breakpoint-prefix}vat {
     vertical-align: top !important;
   }
 
-  .xs-vab {
+  .@{breakpoint-prefix}vab {
     vertical-align: bottom !important;
   }
 
-  .xs-vam {
-    vertical-align: middle !important;
-  }
-},{
-  .sm-vat {
-    vertical-align: top !important;
-  }
-
-  .sm-vab {
-    vertical-align: bottom !important;
-  }
-
-  .sm-vam {
-    vertical-align: middle !important;
-  }
-},{
-  .md-vat {
-    vertical-align: top !important;
-  }
-
-  .md-vab {
-    vertical-align: bottom !important;
-  }
-
-  .md-vam {
-    vertical-align: middle !important;
-  }
-},{
-  .lg-vat {
-    vertical-align: top !important;
-  }
-
-  .lg-vab {
-    vertical-align: bottom !important;
-  }
-
-  .lg-vam {
-    vertical-align: middle !important;
-  }
-},{
-  .xl-vat {
-    vertical-align: top !important;
-  }
-
-  .xl-vab {
-    vertical-align: bottom !important;
-  }
-
-  .xl-vam {
-    vertical-align: middle !important;
-  }
-},{
-  .xxl-vat {
-    vertical-align: top !important;
-  }
-
-  .xxl-vab {
-    vertical-align: bottom !important;
-  }
-
-  .xxl-vam {
+  .@{breakpoint-prefix}vam {
     vertical-align: middle !important;
   }
 });

--- a/utilities/widths.less
+++ b/utilities/widths.less
@@ -4,1457 +4,215 @@
 
 /**
  * Hat tip to @csswizardry for the fraction classes technique.
- * 
+ *
  * @link http://cbrac.co/1RvQXmS
  */
 
-/* Auto */
-.width-auto {
-  width: auto !important;
-}
-
-/* Whole */
-[class~="1/1"],
-.one-whole {
-  width: 100% !important;
-}
-
-/* Halves */
-[class~="1/2"],
-.one-half,
-[class~="2/4"],
-.two-fourths,
-[class~="3/6"],
-.three-sixths,
-[class~="4/8"],
-.four-eighths,
-[class~="5/10"],
-.five-tenths,
-[class~="6/12"],
-.six-twelfths {
-  width: 50% !important;
-}
-
-/* Thirds */
-[class~="1/3"],
-.one-third,
-[class~="2/6"],
-.two-sixths,
-[class~="3/9"],
-.three-ninths,
-[class~="4/12"],
-.four-twelfths {
-  width: 33.3333333% !important;
-}
-
-[class~="2/3"],
-.two-thirds,
-[class~="4/6"],
-.four-sixths,
-[class~="6/9"],
-.six-ninths,
-[class~="8/12"],
-.eight-twelfths {
-  width: 66.6666666% !important;
-}
-
-/* Fourths */
-[class~="1/4"],
-.one-fourth,
-[class~="2/8"],
-.two-eighths,
-[class~="3/12"],
-.three-twelfths {
-  width: 25% !important;
-}
-
-[class~="3/4"],
-.three-fourths,
-[class~="6/8"],
-.six-eighths,
-[class~="9/12"],
-.nine-twelfths {
-  width: 75% !important;
-}
-
-/* Fifths */
-[class~="1/5"],
-.one-fifth,
-[class~="2/10"],
-.two-tenths {
-  width: 20% !important;
-}
-
-[class~="2/5"],
-.two-fifths,
-[class~="4/10"],
-.four-tenths {
-  width: 40% !important;
-}
-
-[class~="3/5"],
-.three-fifths,
-[class~="6/10"],
-.six-tenths {
-  width: 60% !important;
-}
-
-[class~="4/5"],
-.four-fifths,
-[class~="8/10"],
-.eight-tenths {
-  width: 80% !important;
-}
-
-/* Sixths */
-[class~="1/6"],
-.one-sixth,
-[class~="2/12"],
-.two-twelfths {
-  width: 16.6666666% !important;
-}
-
-[class~="5/6"],
-.five-sixths,
-[class~="10/12"],
-.ten-twelfths {
-  width: 83.3333333% !important;
-}
-
-/* Eighths */
-[class~="1/8"],
-.one-eighth {
-  width: 12.5% !important;
-}
-
-[class~="3/8"],
-.three-eighths {
-  width: 37.5% !important;
-}
-
-[class~="5/8"],
-.five-eighths {
-  width: 62.5% !important;
-}
-
-[class~="7/8"],
-.seven-eighths {
-  width: 87.5% !important;
-}
-
-/* Ninths */
-[class~="1/9"],
-.one-ninth {
-  width: 11.1111111% !important;
-}
-
-[class~="2/9"],
-.two-ninths {
-  width: 22.2222222% !important;
-}
-
-[class~="4/9"],
-.four-ninths {
-  width: 44.4444444% !important;
-}
-
-[class~="5/9"],
-.five-ninths {
-  width: 55.5555555% !important;
-}
-
-[class~="7/9"],
-.seven-ninths {
-  width: 77.7777777% !important;
-}
-
-[class~="8/9"],
-.eight-ninths {
-  width: 88.8888888% !important;
-}
-
-/* Tenths */
-[class~="1/10"],
-.one-tenth {
-  width: 10% !important;
-}
-
-[class~="3/10"],
-.three-tenths {
-  width: 30% !important;
-}
-
-[class~="7/10"],
-.seven-tenths {
-  width: 70% !important;
-}
-
-[class~="9/10"],
-.nine-tenths {
-  width: 90% !important;
-}
-
-/* Twelfths */
-[class~="1/12"],
-.one-twelfth {
-  width:  8.3333333% !important;
-}
-
-[class~="5/12"],
-.five-twelfths {
-  width: 41.6666666% !important;
-}
-
-[class~="7/12"],
-.seven-twelfths {
-  width: 58.3333333% !important;
-}
-
-[class~="11/12"],
-.eleven-twelfths {
-  width: 91.6666666% !important;
-}
-
-.screens({
+.breakpoint-prefixes({
   // Auto
-  .xs-width-auto {
+  .@{breakpoint-prefix}width-auto {
     width: auto !important;
   }
 
   // Whole
-  [class~="xs-1/1"],
-  .xs-one-whole {
+  [class~="@{breakpoint-prefix}1/1"],
+  .@{breakpoint-prefix}one-whole {
     width: 100% !important;
   }
 
   // Halves
-  [class~="xs-1/2"],
-  .xs-one-half,
-  [class~="xs-2/4"],
-  .xs-two-fourths,
-  [class~="xs-3/6"],
-  .xs-three-sixths,
-  [class~="xs-4/8"],
-  .xs-four-eighths,
-  [class~="xs-5/10"],
-  .xs-five-tenths,
-  [class~="xs-6/12"],
-  .xs-six-twelfths {
+  [class~="@{breakpoint-prefix}1/2"],
+  .@{breakpoint-prefix}one-half,
+  [class~="@{breakpoint-prefix}2/4"],
+  .@{breakpoint-prefix}two-fourths,
+  [class~="@{breakpoint-prefix}3/6"],
+  .@{breakpoint-prefix}three-sixths,
+  [class~="@{breakpoint-prefix}4/8"],
+  .@{breakpoint-prefix}four-eighths,
+  [class~="@{breakpoint-prefix}5/10"],
+  .@{breakpoint-prefix}five-tenths,
+  [class~="@{breakpoint-prefix}6/12"],
+  .@{breakpoint-prefix}six-twelfths {
     width: 50% !important;
   }
 
   // Thirds
-  [class~="xs-1/3"],
-  .xs-one-third,
-  [class~="xs-2/6"],
-  .xs-two-sixths,
-  [class~="xs-3/9"],
-  .xs-three-ninths,
-  [class~="xs-4/12"],
-  .xs-four-twelfths {
+  [class~="@{breakpoint-prefix}1/3"],
+  .@{breakpoint-prefix}one-third,
+  [class~="@{breakpoint-prefix}2/6"],
+  .@{breakpoint-prefix}two-sixths,
+  [class~="@{breakpoint-prefix}3/9"],
+  .@{breakpoint-prefix}three-ninths,
+  [class~="@{breakpoint-prefix}4/12"],
+  .@{breakpoint-prefix}four-twelfths {
     width: 33.3333333% !important;
   }
 
-  [class~="xs-2/3"],
-  .xs-two-thirds,
-  [class~="xs-4/6"],
-  .xs-four-sixths,
-  [class~="xs-6/9"],
-  .xs-six-ninths,
-  [class~="xs-8/12"],
-  .xs-eight-twelfths {
+  [class~="@{breakpoint-prefix}2/3"],
+  .@{breakpoint-prefix}two-thirds,
+  [class~="@{breakpoint-prefix}4/6"],
+  .@{breakpoint-prefix}four-sixths,
+  [class~="@{breakpoint-prefix}6/9"],
+  .@{breakpoint-prefix}six-ninths,
+  [class~="@{breakpoint-prefix}8/12"],
+  .@{breakpoint-prefix}eight-twelfths {
     width: 66.6666666% !important;
   }
 
   // Fourths
-  [class~="xs-1/4"],
-  .xs-one-fourth,
-  [class~="xs-2/8"],
-  .xs-two-eighths,
-  [class~="xs-3/12"],
-  .xs-three-twelfths {
+  [class~="@{breakpoint-prefix}1/4"],
+  .@{breakpoint-prefix}one-fourth,
+  [class~="@{breakpoint-prefix}2/8"],
+  .@{breakpoint-prefix}two-eighths,
+  [class~="@{breakpoint-prefix}3/12"],
+  .@{breakpoint-prefix}three-twelfths {
     width: 25% !important;
   }
 
-  [class~="xs-3/4"],
-  .xs-three-fourths,
-  [class~="xs-6/8"],
-  .xs-six-eighths,
-  [class~="xs-9/12"],
-  .xs-nine-twelfths {
+  [class~="@{breakpoint-prefix}3/4"],
+  .@{breakpoint-prefix}three-fourths,
+  [class~="@{breakpoint-prefix}6/8"],
+  .@{breakpoint-prefix}six-eighths,
+  [class~="@{breakpoint-prefix}9/12"],
+  .@{breakpoint-prefix}nine-twelfths {
     width: 75% !important;
   }
 
   // Fifths
-  [class~="xs-1/5"],
-  .xs-one-fifth,
-  [class~="xs-2/10"],
-  .xs-two-tenths {
+  [class~="@{breakpoint-prefix}1/5"],
+  .@{breakpoint-prefix}one-fifth,
+  [class~="@{breakpoint-prefix}2/10"],
+  .@{breakpoint-prefix}two-tenths {
     width: 20% !important;
   }
 
-  [class~="xs-2/5"],
-  .xs-two-fifths,
-  [class~="xs-4/10"],
-  .xs-four-tenths {
+  [class~="@{breakpoint-prefix}2/5"],
+  .@{breakpoint-prefix}two-fifths,
+  [class~="@{breakpoint-prefix}4/10"],
+  .@{breakpoint-prefix}four-tenths {
     width: 40% !important;
   }
 
-  [class~="xs-3/5"],
-  .xs-three-fifths,
-  [class~="xs-6/10"],
-  .xs-six-tenths {
+  [class~="@{breakpoint-prefix}3/5"],
+  .@{breakpoint-prefix}three-fifths,
+  [class~="@{breakpoint-prefix}6/10"],
+  .@{breakpoint-prefix}six-tenths {
     width: 60% !important;
   }
 
-  [class~="xs-4/5"],
-  .xs-four-fifths,
-  [class~="xs-8/10"],
-  .xs-eight-tenths {
+  [class~="@{breakpoint-prefix}4/5"],
+  .@{breakpoint-prefix}four-fifths,
+  [class~="@{breakpoint-prefix}8/10"],
+  .@{breakpoint-prefix}eight-tenths {
     width: 80% !important;
   }
 
   // Sixths
-  [class~="xs-1/6"],
-  .xs-one-sixth,
-  [class~="xs-2/12"],
-  .xs-two-twelfths {
+  [class~="@{breakpoint-prefix}1/6"],
+  .@{breakpoint-prefix}one-sixth,
+  [class~="@{breakpoint-prefix}2/12"],
+  .@{breakpoint-prefix}two-twelfths {
     width: 16.6666666% !important;
   }
 
-  [class~="xs-5/6"],
-  .xs-five-sixths,
-  [class~="xs-10/12"],
-  .xs-ten-twelfths {
+  [class~="@{breakpoint-prefix}5/6"],
+  .@{breakpoint-prefix}five-sixths,
+  [class~="@{breakpoint-prefix}10/12"],
+  .@{breakpoint-prefix}ten-twelfths {
     width: 83.3333333% !important;
   }
 
   // Eighths
-  [class~="xs-1/8"],
-  .xs-one-eighth {
+  [class~="@{breakpoint-prefix}1/8"],
+  .@{breakpoint-prefix}one-eighth {
     width: 12.5% !important;
   }
 
-  [class~="xs-3/8"],
-  .xs-three-eighths {
+  [class~="@{breakpoint-prefix}3/8"],
+  .@{breakpoint-prefix}three-eighths {
     width: 37.5% !important;
   }
 
-  [class~="xs-5/8"],
-  .xs-five-eighths {
+  [class~="@{breakpoint-prefix}5/8"],
+  .@{breakpoint-prefix}five-eighths {
     width: 62.5% !important;
   }
 
-  [class~="xs-7/8"],
-  .xs-seven-eighths {
+  [class~="@{breakpoint-prefix}7/8"],
+  .@{breakpoint-prefix}seven-eighths {
     width: 87.5% !important;
   }
 
   // Ninths
-  [class~="xs-1/9"],
-  .xs-one-ninth {
+  [class~="@{breakpoint-prefix}1/9"],
+  .@{breakpoint-prefix}one-ninth {
     width: 11.1111111% !important;
   }
 
-  [class~="xs-2/9"],
-  .xs-two-ninths {
+  [class~="@{breakpoint-prefix}2/9"],
+  .@{breakpoint-prefix}two-ninths {
     width: 22.2222222% !important;
   }
 
-  [class~="xs-4/9"],
-  .xs-four-ninths {
+  [class~="@{breakpoint-prefix}4/9"],
+  .@{breakpoint-prefix}four-ninths {
     width: 44.4444444% !important;
   }
 
-  [class~="xs-5/9"],
-  .xs-five-ninths {
+  [class~="@{breakpoint-prefix}5/9"],
+  .@{breakpoint-prefix}five-ninths {
     width: 55.5555555% !important;
   }
 
-  [class~="xs-7/9"],
-  .xs-seven-ninths {
+  [class~="@{breakpoint-prefix}7/9"],
+  .@{breakpoint-prefix}seven-ninths {
     width: 77.7777777% !important;
   }
 
-  [class~="xs-8/9"],
-  .xs-eight-ninths {
+  [class~="@{breakpoint-prefix}8/9"],
+  .@{breakpoint-prefix}eight-ninths {
     width: 88.8888888% !important;
   }
 
   // Tenths
-  [class~="xs-1/10"],
-  .xs-one-tenth {
+  [class~="@{breakpoint-prefix}1/10"],
+  .@{breakpoint-prefix}one-tenth {
     width: 10% !important;
   }
 
-  [class~="xs-3/10"],
-  .xs-three-tenths {
+  [class~="@{breakpoint-prefix}3/10"],
+  .@{breakpoint-prefix}three-tenths {
     width: 30% !important;
   }
 
-  [class~="xs-7/10"],
-  .xs-seven-tenths {
+  [class~="@{breakpoint-prefix}7/10"],
+  .@{breakpoint-prefix}seven-tenths {
     width: 70% !important;
   }
 
-  [class~="xs-9/10"],
-  .xs-nine-tenths {
+  [class~="@{breakpoint-prefix}9/10"],
+  .@{breakpoint-prefix}nine-tenths {
     width: 90% !important;
   }
 
   // Twelfths
-  [class~="xs-1/12"],
-  .xs-one-twelfth {
+  [class~="@{breakpoint-prefix}1/12"],
+  .@{breakpoint-prefix}one-twelfth {
     width:  8.3333333% !important;
   }
 
-  [class~="xs-5/12"],
-  .xs-five-twelfths {
+  [class~="@{breakpoint-prefix}5/12"],
+  .@{breakpoint-prefix}five-twelfths {
     width: 41.6666666% !important;
   }
 
-  [class~="xs-7/12"],
-  .xs-seven-twelfths {
+  [class~="@{breakpoint-prefix}7/12"],
+  .@{breakpoint-prefix}seven-twelfths {
     width: 58.3333333% !important;
   }
 
-  [class~="xs-11/12"],
-  .xs-eleven-twelfths {
-    width: 91.6666666% !important;
-  }
-},{
-  // Auto
-  .sm-width-auto {
-    width: auto !important;
-  }
-
-  // Whole
-  [class~="sm-1/1"],
-  .sm-one-whole {
-    width: 100% !important;
-  }
-
-  // Halves
-  [class~="sm-1/2"],
-  .sm-one-half,
-  [class~="sm-2/4"],
-  .sm-two-fourths,
-  [class~="sm-3/6"],
-  .sm-three-sixths,
-  [class~="sm-4/8"],
-  .sm-four-eighths,
-  [class~="sm-5/10"],
-  .sm-five-tenths,
-  [class~="sm-6/12"],
-  .sm-six-twelfths {
-    width: 50% !important;
-  }
-
-  // Thirds
-  [class~="sm-1/3"],
-  .sm-one-third,
-  [class~="sm-2/6"],
-  .sm-two-sixths,
-  [class~="sm-3/9"],
-  .sm-three-ninths,
-  [class~="sm-4/12"],
-  .sm-four-twelfths {
-    width: 33.3333333% !important;
-  }
-
-  [class~="sm-2/3"],
-  .sm-two-thirds,
-  [class~="sm-4/6"],
-  .sm-four-sixths,
-  [class~="sm-6/9"],
-  .sm-six-ninths,
-  [class~="sm-8/12"],
-  .sm-eight-twelfths {
-    width: 66.6666666% !important;
-  }
-
-  // Fourths
-  [class~="sm-1/4"],
-  .sm-one-fourth,
-  [class~="sm-2/8"],
-  .sm-two-eighths,
-  [class~="sm-3/12"],
-  .sm-three-twelfths {
-    width: 25% !important;
-  }
-
-  [class~="sm-3/4"],
-  .sm-three-fourths,
-  [class~="sm-6/8"],
-  .sm-six-eighths,
-  [class~="sm-9/12"],
-  .sm-nine-twelfths {
-    width: 75% !important;
-  }
-
-  // Fifths
-  [class~="sm-1/5"],
-  .sm-one-fifth,
-  [class~="sm-2/10"],
-  .sm-two-tenths {
-    width: 20% !important;
-  }
-
-  [class~="sm-2/5"],
-  .sm-two-fifths,
-  [class~="sm-4/10"],
-  .sm-four-tenths {
-    width: 40% !important;
-  }
-
-  [class~="sm-3/5"],
-  .sm-three-fifths,
-  [class~="sm-6/10"],
-  .sm-six-tenths {
-    width: 60% !important;
-  }
-
-  [class~="sm-4/5"],
-  .sm-four-fifths,
-  [class~="sm-8/10"],
-  .sm-eight-tenths {
-    width: 80% !important;
-  }
-
-  // Sixths
-  [class~="sm-1/6"],
-  .sm-one-sixth,
-  [class~="sm-2/12"],
-  .sm-two-twelfths {
-    width: 16.6666666% !important;
-  }
-
-  [class~="sm-5/6"],
-  .sm-five-sixths,
-  [class~="sm-10/12"],
-  .sm-ten-twelfths {
-    width: 83.3333333% !important;
-  }
-
-  // Eighths
-  [class~="sm-1/8"],
-  .sm-one-eighth {
-    width: 12.5% !important;
-  }
-
-  [class~="sm-3/8"],
-  .sm-three-eighths {
-    width: 37.5% !important;
-  }
-
-  [class~="sm-5/8"],
-  .sm-five-eighths {
-    width: 62.5% !important;
-  }
-
-  [class~="sm-7/8"],
-  .sm-seven-eighths {
-    width: 87.5% !important;
-  }
-
-  // Ninths
-  [class~="sm-1/9"],
-  .sm-one-ninth {
-    width: 11.1111111% !important;
-  }
-
-  [class~="sm-2/9"],
-  .sm-two-ninths {
-    width: 22.2222222% !important;
-  }
-
-  [class~="sm-4/9"],
-  .sm-four-ninths {
-    width: 44.4444444% !important;
-  }
-
-  [class~="sm-5/9"],
-  .sm-five-ninths {
-    width: 55.5555555% !important;
-  }
-
-  [class~="sm-7/9"],
-  .sm-seven-ninths {
-    width: 77.7777777% !important;
-  }
-
-  [class~="sm-8/9"],
-  .sm-eight-ninths {
-    width: 88.8888888% !important;
-  }
-
-  // Tenths
-  [class~="sm-1/10"],
-  .sm-one-tenth {
-    width: 10% !important;
-  }
-
-  [class~="sm-3/10"],
-  .sm-three-tenths {
-    width: 30% !important;
-  }
-
-  [class~="sm-7/10"],
-  .sm-seven-tenths {
-    width: 70% !important;
-  }
-
-  [class~="sm-9/10"],
-  .sm-nine-tenths {
-    width: 90% !important;
-  }
-
-  // Twelfths
-  [class~="sm-1/12"],
-  .sm-one-twelfth {
-    width:  8.3333333% !important;
-  }
-
-  [class~="sm-5/12"],
-  .sm-five-twelfths {
-    width: 41.6666666% !important;
-  }
-
-  [class~="sm-7/12"],
-  .sm-seven-twelfths {
-    width: 58.3333333% !important;
-  }
-
-  [class~="sm-11/12"],
-  .sm-eleven-twelfths {
-    width: 91.6666666% !important;
-  }
-},{
-  // Auto
-  .md-width-auto {
-    width: auto !important;
-  }
-
-  // Whole
-  [class~="md-1/1"],
-  .md-one-whole {
-    width: 100% !important;
-  }
-
-  // Halves
-  [class~="md-1/2"],
-  .md-one-half,
-  [class~="md-2/4"],
-  .md-two-fourths,
-  [class~="md-3/6"],
-  .md-three-sixths,
-  [class~="md-4/8"],
-  .md-four-eighths,
-  [class~="md-5/10"],
-  .md-five-tenths,
-  [class~="md-6/12"],
-  .md-six-twelfths {
-    width: 50% !important;
-  }
-
-  // Thirds
-  [class~="md-1/3"],
-  .md-one-third,
-  [class~="md-2/6"],
-  .md-two-sixths,
-  [class~="md-3/9"],
-  .md-three-ninths,
-  [class~="md-4/12"],
-  .md-four-twelfths {
-    width: 33.3333333% !important;
-  }
-
-  [class~="md-2/3"],
-  .md-two-thirds,
-  [class~="md-4/6"],
-  .md-four-sixths,
-  [class~="md-6/9"],
-  .md-six-ninths,
-  [class~="md-8/12"],
-  .md-eight-twelfths {
-    width: 66.6666666% !important;
-  }
-
-  // Fourths
-  [class~="md-1/4"],
-  .md-one-fourth,
-  [class~="md-2/8"],
-  .md-two-eighths,
-  [class~="md-3/12"],
-  .md-three-twelfths {
-    width: 25% !important;
-  }
-
-  [class~="md-3/4"],
-  .md-three-fourths,
-  [class~="md-6/8"],
-  .md-six-eighths,
-  [class~="md-9/12"],
-  .md-nine-twelfths {
-    width: 75% !important;
-  }
-
-  // Fifths
-  [class~="md-1/5"],
-  .md-one-fifth,
-  [class~="md-2/10"],
-  .md-two-tenths {
-    width: 20% !important;
-  }
-
-  [class~="md-2/5"],
-  .md-two-fifths,
-  [class~="md-4/10"],
-  .md-four-tenths {
-    width: 40% !important;
-  }
-
-  [class~="md-3/5"],
-  .md-three-fifths,
-  [class~="md-6/10"],
-  .md-six-tenths {
-    width: 60% !important;
-  }
-
-  [class~="md-4/5"],
-  .md-four-fifths,
-  [class~="md-8/10"],
-  .md-eight-tenths {
-    width: 80% !important;
-  }
-
-  // Sixths
-  [class~="md-1/6"],
-  .md-one-sixth,
-  [class~="md-2/12"],
-  .md-two-twelfths {
-    width: 16.6666666% !important;
-  }
-
-  [class~="md-5/6"],
-  .md-five-sixths,
-  [class~="md-10/12"],
-  .md-ten-twelfths {
-    width: 83.3333333% !important;
-  }
-
-  // Eighths
-  [class~="md-1/8"],
-  .md-one-eighth {
-    width: 12.5% !important;
-  }
-
-  [class~="md-3/8"],
-  .md-three-eighths {
-    width: 37.5% !important;
-  }
-
-  [class~="md-5/8"],
-  .md-five-eighths {
-    width: 62.5% !important;
-  }
-
-  [class~="md-7/8"],
-  .md-seven-eighths {
-    width: 87.5% !important;
-  }
-
-  // Ninths
-  [class~="md-1/9"],
-  .md-one-ninth {
-    width: 11.1111111% !important;
-  }
-
-  [class~="md-2/9"],
-  .md-two-ninths {
-    width: 22.2222222% !important;
-  }
-
-  [class~="md-4/9"],
-  .md-four-ninths {
-    width: 44.4444444% !important;
-  }
-
-  [class~="md-5/9"],
-  .md-five-ninths {
-    width: 55.5555555% !important;
-  }
-
-  [class~="md-7/9"],
-  .md-seven-ninths {
-    width: 77.7777777% !important;
-  }
-
-  [class~="md-8/9"],
-  .md-eight-ninths {
-    width: 88.8888888% !important;
-  }
-
-  // Tenths
-  [class~="md-1/10"],
-  .md-one-tenth {
-    width: 10% !important;
-  }
-
-  [class~="md-3/10"],
-  .md-three-tenths {
-    width: 30% !important;
-  }
-
-  [class~="md-7/10"],
-  .md-seven-tenths {
-    width: 70% !important;
-  }
-
-  [class~="md-9/10"],
-  .md-nine-tenths {
-    width: 90% !important;
-  }
-
-  // Twelfths
-  [class~="md-1/12"],
-  .md-one-twelfth {
-    width:  8.3333333% !important;
-  }
-
-  [class~="md-5/12"],
-  .md-five-twelfths {
-    width: 41.6666666% !important;
-  }
-
-  [class~="md-7/12"],
-  .md-seven-twelfths {
-    width: 58.3333333% !important;
-  }
-
-  [class~="md-11/12"],
-  .md-eleven-twelfths {
-    width: 91.6666666% !important;
-  }
-},{
-  // Auto
-  .lg-width-auto {
-    width: auto !important;
-  }
-
-  // Whole
-  [class~="lg-1/1"],
-  .lg-one-whole {
-    width: 100% !important;
-  }
-
-  // Halves
-  [class~="lg-1/2"],
-  .lg-one-half,
-  [class~="lg-2/4"],
-  .lg-two-fourths,
-  [class~="lg-3/6"],
-  .lg-three-sixths,
-  [class~="lg-4/8"],
-  .lg-four-eighths,
-  [class~="lg-5/10"],
-  .lg-five-tenths,
-  [class~="lg-6/12"],
-  .lg-six-twelfths {
-    width: 50% !important;
-  }
-
-  // Thirds
-  [class~="lg-1/3"],
-  .lg-one-third,
-  [class~="lg-2/6"],
-  .lg-two-sixths,
-  [class~="lg-3/9"],
-  .lg-three-ninths,
-  [class~="lg-4/12"],
-  .lg-four-twelfths {
-    width: 33.3333333% !important;
-  }
-
-  [class~="lg-2/3"],
-  .lg-two-thirds,
-  [class~="lg-4/6"],
-  .lg-four-sixths,
-  [class~="lg-6/9"],
-  .lg-six-ninths,
-  [class~="lg-8/12"],
-  .lg-eight-twelfths {
-    width: 66.6666666% !important;
-  }
-
-  // Fourths
-  [class~="lg-1/4"],
-  .lg-one-fourth,
-  [class~="lg-2/8"],
-  .lg-two-eighths,
-  [class~="lg-3/12"],
-  .lg-three-twelfths {
-    width: 25% !important;
-  }
-
-  [class~="lg-3/4"],
-  .lg-three-fourths,
-  [class~="lg-6/8"],
-  .lg-six-eighths,
-  [class~="lg-9/12"],
-  .lg-nine-twelfths {
-    width: 75% !important;
-  }
-
-  // Fifths
-  [class~="lg-1/5"],
-  .lg-one-fifth,
-  [class~="lg-2/10"],
-  .lg-two-tenths {
-    width: 20% !important;
-  }
-
-  [class~="lg-2/5"],
-  .lg-two-fifths,
-  [class~="lg-4/10"],
-  .lg-four-tenths {
-    width: 40% !important;
-  }
-
-  [class~="lg-3/5"],
-  .lg-three-fifths,
-  [class~="lg-6/10"],
-  .lg-six-tenths {
-    width: 60% !important;
-  }
-
-  [class~="lg-4/5"],
-  .lg-four-fifths,
-  [class~="lg-8/10"],
-  .lg-eight-tenths {
-    width: 80% !important;
-  }
-
-  // Sixths
-  [class~="lg-1/6"],
-  .lg-one-sixth,
-  [class~="lg-2/12"],
-  .lg-two-twelfths {
-    width: 16.6666666% !important;
-  }
-
-  [class~="lg-5/6"],
-  .lg-five-sixths,
-  [class~="lg-10/12"],
-  .lg-ten-twelfths {
-    width: 83.3333333% !important;
-  }
-
-  // Eighths
-  [class~="lg-1/8"],
-  .lg-one-eighth {
-    width: 12.5% !important;
-  }
-
-  [class~="lg-3/8"],
-  .lg-three-eighths {
-    width: 37.5% !important;
-  }
-
-  [class~="lg-5/8"],
-  .lg-five-eighths {
-    width: 62.5% !important;
-  }
-
-  [class~="lg-7/8"],
-  .lg-seven-eighths {
-    width: 87.5% !important;
-  }
-
-  // Ninths
-  [class~="lg-1/9"],
-  .lg-one-ninth {
-    width: 11.1111111% !important;
-  }
-
-  [class~="lg-2/9"],
-  .lg-two-ninths {
-    width: 22.2222222% !important;
-  }
-
-  [class~="lg-4/9"],
-  .lg-four-ninths {
-    width: 44.4444444% !important;
-  }
-
-  [class~="lg-5/9"],
-  .lg-five-ninths {
-    width: 55.5555555% !important;
-  }
-
-  [class~="lg-7/9"],
-  .lg-seven-ninths {
-    width: 77.7777777% !important;
-  }
-
-  [class~="lg-8/9"],
-  .lg-eight-ninths {
-    width: 88.8888888% !important;
-  }
-
-  // Tenths
-  [class~="lg-1/10"],
-  .lg-one-tenth {
-    width: 10% !important;
-  }
-
-  [class~="lg-3/10"],
-  .lg-three-tenths {
-    width: 30% !important;
-  }
-
-  [class~="lg-7/10"],
-  .lg-seven-tenths {
-    width: 70% !important;
-  }
-
-  [class~="lg-9/10"],
-  .lg-nine-tenths {
-    width: 90% !important;
-  }
-
-  // Twelfths
-  [class~="lg-1/12"],
-  .lg-one-twelfth {
-    width:  8.3333333% !important;
-  }
-
-  [class~="lg-5/12"],
-  .lg-five-twelfths {
-    width: 41.6666666% !important;
-  }
-
-  [class~="lg-7/12"],
-  .lg-seven-twelfths {
-    width: 58.3333333% !important;
-  }
-
-  [class~="lg-11/12"],
-  .lg-eleven-twelfths {
-    width: 91.6666666% !important;
-  }
-},{
-  // Auto
-  .xl-width-auto {
-    width: auto !important;
-  }
-
-  // Whole
-  [class~="xl-1/1"],
-  .xl-one-whole {
-    width: 100% !important;
-  }
-
-  // Halves
-  [class~="xl-1/2"],
-  .xl-one-half,
-  [class~="xl-2/4"],
-  .xl-two-fourths,
-  [class~="xl-3/6"],
-  .xl-three-sixths,
-  [class~="xl-4/8"],
-  .xl-four-eighths,
-  [class~="xl-5/10"],
-  .xl-five-tenths,
-  [class~="xl-6/12"],
-  .xl-six-twelfths {
-    width: 50% !important;
-  }
-
-  // Thirds
-  [class~="xl-1/3"],
-  .xl-one-third,
-  [class~="xl-2/6"],
-  .xl-two-sixths,
-  [class~="xl-3/9"],
-  .xl-three-ninths,
-  [class~="xl-4/12"],
-  .xl-four-twelfths {
-    width: 33.3333333% !important;
-  }
-
-  [class~="xl-2/3"],
-  .xl-two-thirds,
-  [class~="xl-4/6"],
-  .xl-four-sixths,
-  [class~="xl-6/9"],
-  .xl-six-ninths,
-  [class~="xl-8/12"],
-  .xl-eight-twelfths {
-    width: 66.6666666% !important;
-  }
-
-  // Fourths
-  [class~="xl-1/4"],
-  .xl-one-fourth,
-  [class~="xl-2/8"],
-  .xl-two-eighths,
-  [class~="xl-3/12"],
-  .xl-three-twelfths {
-    width: 25% !important;
-  }
-
-  [class~="xl-3/4"],
-  .xl-three-fourths,
-  [class~="xl-6/8"],
-  .xl-six-eighths,
-  [class~="xl-9/12"],
-  .xl-nine-twelfths {
-    width: 75% !important;
-  }
-
-  // Fifths
-  [class~="xl-1/5"],
-  .xl-one-fifth,
-  [class~="xl-2/10"],
-  .xl-two-tenths {
-    width: 20% !important;
-  }
-
-  [class~="xl-2/5"],
-  .xl-two-fifths,
-  [class~="xl-4/10"],
-  .xl-four-tenths {
-    width: 40% !important;
-  }
-
-  [class~="xl-3/5"],
-  .xl-three-fifths,
-  [class~="xl-6/10"],
-  .xl-six-tenths {
-    width: 60% !important;
-  }
-
-  [class~="xl-4/5"],
-  .xl-four-fifths,
-  [class~="xl-8/10"],
-  .xl-eight-tenths {
-    width: 80% !important;
-  }
-
-  // Sixths
-  [class~="xl-1/6"],
-  .xl-one-sixth,
-  [class~="xl-2/12"],
-  .xl-two-twelfths {
-    width: 16.6666666% !important;
-  }
-
-  [class~="xl-5/6"],
-  .xl-five-sixths,
-  [class~="xl-10/12"],
-  .xl-ten-twelfths {
-    width: 83.3333333% !important;
-  }
-
-  // Eighths
-  [class~="xl-1/8"],
-  .xl-one-eighth {
-    width: 12.5% !important;
-  }
-
-  [class~="xl-3/8"],
-  .xl-three-eighths {
-    width: 37.5% !important;
-  }
-
-  [class~="xl-5/8"],
-  .xl-five-eighths {
-    width: 62.5% !important;
-  }
-
-  [class~="xl-7/8"],
-  .xl-seven-eighths {
-    width: 87.5% !important;
-  }
-
-  // Ninths
-  [class~="xl-1/9"],
-  .xl-one-ninth {
-    width: 11.1111111% !important;
-  }
-
-  [class~="xl-2/9"],
-  .xl-two-ninths {
-    width: 22.2222222% !important;
-  }
-
-  [class~="xl-4/9"],
-  .xl-four-ninths {
-    width: 44.4444444% !important;
-  }
-
-  [class~="xl-5/9"],
-  .xl-five-ninths {
-    width: 55.5555555% !important;
-  }
-
-  [class~="xl-7/9"],
-  .xl-seven-ninths {
-    width: 77.7777777% !important;
-  }
-
-  [class~="xl-8/9"],
-  .xl-eight-ninths {
-    width: 88.8888888% !important;
-  }
-
-  // Tenths
-  [class~="xl-1/10"],
-  .xl-one-tenth {
-    width: 10% !important;
-  }
-
-  [class~="xl-3/10"],
-  .xl-three-tenths {
-    width: 30% !important;
-  }
-
-  [class~="xl-7/10"],
-  .xl-seven-tenths {
-    width: 70% !important;
-  }
-
-  [class~="xl-9/10"],
-  .xl-nine-tenths {
-    width: 90% !important;
-  }
-
-  // Twelfths
-  [class~="xl-1/12"],
-  .xl-one-twelfth {
-    width:  8.3333333% !important;
-  }
-
-  [class~="xl-5/12"],
-  .xl-five-twelfths {
-    width: 41.6666666% !important;
-  }
-
-  [class~="xl-7/12"],
-  .xl-seven-twelfths {
-    width: 58.3333333% !important;
-  }
-
-  [class~="xl-11/12"],
-  .xl-eleven-twelfths {
-    width: 91.6666666% !important;
-  }
-},{
-  // Auto
-  .xxl-width-auto {
-    width: auto !important;
-  }
-
-  // Whole
-  [class~="xxl-1/1"],
-  .xxl-one-whole {
-    width: 100% !important;
-  }
-
-  // Halves
-  [class~="xxl-1/2"],
-  .xxl-one-half,
-  [class~="xxl-2/4"],
-  .xxl-two-fourths,
-  [class~="xxl-3/6"],
-  .xxl-three-sixths,
-  [class~="xxl-4/8"],
-  .xxl-four-eighths,
-  [class~="xxl-5/10"],
-  .xxl-five-tenths,
-  [class~="xxl-6/12"],
-  .xxl-six-twelfths {
-    width: 50% !important;
-  }
-
-  // Thirds
-  [class~="xxl-1/3"],
-  .xxl-one-third,
-  [class~="xxl-2/6"],
-  .xxl-two-sixths,
-  [class~="xxl-3/9"],
-  .xxl-three-ninths,
-  [class~="xxl-4/12"],
-  .xxl-four-twelfths {
-    width: 33.3333333% !important;
-  }
-
-  [class~="xxl-2/3"],
-  .xxl-two-thirds,
-  [class~="xxl-4/6"],
-  .xxl-four-sixths,
-  [class~="xxl-6/9"],
-  .xxl-six-ninths,
-  [class~="xxl-8/12"],
-  .xxl-eight-twelfths {
-    width: 66.6666666% !important;
-  }
-
-  // Fourths
-  [class~="xxl-1/4"],
-  .xxl-one-fourth,
-  [class~="xxl-2/8"],
-  .xxl-two-eighths,
-  [class~="xxl-3/12"],
-  .xxl-three-twelfths {
-    width: 25% !important;
-  }
-
-  [class~="xxl-3/4"],
-  .xxl-three-fourths,
-  [class~="xxl-6/8"],
-  .xxl-six-eighths,
-  [class~="xxl-9/12"],
-  .xxl-nine-twelfths {
-    width: 75% !important;
-  }
-
-  // Fifths
-  [class~="xxl-1/5"],
-  .xxl-one-fifth,
-  [class~="xxl-2/10"],
-  .xxl-two-tenths {
-    width: 20% !important;
-  }
-
-  [class~="xxl-2/5"],
-  .xxl-two-fifths,
-  [class~="xxl-4/10"],
-  .xxl-four-tenths {
-    width: 40% !important;
-  }
-
-  [class~="xxl-3/5"],
-  .xxl-three-fifths,
-  [class~="xxl-6/10"],
-  .xxl-six-tenths {
-    width: 60% !important;
-  }
-
-  [class~="xxl-4/5"],
-  .xxl-four-fifths,
-  [class~="xxl-8/10"],
-  .xxl-eight-tenths {
-    width: 80% !important;
-  }
-
-  // Sixths
-  [class~="xxl-1/6"],
-  .xxl-one-sixth,
-  [class~="xxl-2/12"],
-  .xxl-two-twelfths {
-    width: 16.6666666% !important;
-  }
-
-  [class~="xxl-5/6"],
-  .xxl-five-sixths,
-  [class~="xxl-10/12"],
-  .xxl-ten-twelfths {
-    width: 83.3333333% !important;
-  }
-
-  // Eighths
-  [class~="xxl-1/8"],
-  .xxl-one-eighth {
-    width: 12.5% !important;
-  }
-
-  [class~="xxl-3/8"],
-  .xxl-three-eighths {
-    width: 37.5% !important;
-  }
-
-  [class~="xxl-5/8"],
-  .xxl-five-eighths {
-    width: 62.5% !important;
-  }
-
-  [class~="xxl-7/8"],
-  .xxl-seven-eighths {
-    width: 87.5% !important;
-  }
-
-  // Ninths
-  [class~="xxl-1/9"],
-  .xxl-one-ninth {
-    width: 11.1111111% !important;
-  }
-
-  [class~="xxl-2/9"],
-  .xxl-two-ninths {
-    width: 22.2222222% !important;
-  }
-
-  [class~="xxl-4/9"],
-  .xxl-four-ninths {
-    width: 44.4444444% !important;
-  }
-
-  [class~="xxl-5/9"],
-  .xxl-five-ninths {
-    width: 55.5555555% !important;
-  }
-
-  [class~="xxl-7/9"],
-  .xxl-seven-ninths {
-    width: 77.7777777% !important;
-  }
-
-  [class~="xxl-8/9"],
-  .xxl-eight-ninths {
-    width: 88.8888888% !important;
-  }
-
-  // Tenths
-  [class~="xxl-1/10"],
-  .xxl-one-tenth {
-    width: 10% !important;
-  }
-
-  [class~="xxl-3/10"],
-  .xxl-three-tenths {
-    width: 30% !important;
-  }
-
-  [class~="xxl-7/10"],
-  .xxl-seven-tenths {
-    width: 70% !important;
-  }
-
-  [class~="xxl-9/10"],
-  .xxl-nine-tenths {
-    width: 90% !important;
-  }
-
-  // Twelfths
-  [class~="xxl-1/12"],
-  .xxl-one-twelfth {
-    width:  8.3333333% !important;
-  }
-
-  [class~="xxl-5/12"],
-  .xxl-five-twelfths {
-    width: 41.6666666% !important;
-  }
-
-  [class~="xxl-7/12"],
-  .xxl-seven-twelfths {
-    width: 58.3333333% !important;
-  }
-
-  [class~="xxl-11/12"],
-  .xxl-eleven-twelfths {
+  [class~="@{breakpoint-prefix}11/12"],
+  .@{breakpoint-prefix}eleven-twelfths {
     width: 91.6666666% !important;
   }
 });

--- a/utilities/z-index.less
+++ b/utilities/z-index.less
@@ -8,285 +8,44 @@
 // # = value
 //
 
-.z1 {
-  z-index: @z-index-1 !important;
-}
-
-.z2 {
-  z-index: @z-index-2 !important;
-}
-
-.z3 {
-  z-index: @z-index-3 !important;
-}
-
-.z4 {
-  z-index: @z-index-4 !important;
-}
-
-.z5 {
-  z-index: @z-index-5 !important;
-}
-
-.z6 {
-  z-index: @z-index-6 !important;
-}
-
-.z7 {
-  z-index: @z-index-7 !important;
-}
-
-.z8 {
-  z-index: @z-index-8 !important;
-}
-
-.z9 {
-  z-index: @z-index-9 !important;
-}
-
-.z10 {
-  z-index: @z-index-10 !important;
-}
-
-.screens({
-  .xs-z1 {
+.breakpoint-prefixes({
+  .@{breakpoint-prefix}z1 {
     z-index: @z-index-1 !important;
   }
 
-  .xs-z2 {
+  .@{breakpoint-prefix}z2 {
     z-index: @z-index-2 !important;
   }
 
-  .xs-z3 {
+  .@{breakpoint-prefix}z3 {
     z-index: @z-index-3 !important;
   }
 
-  .xs-z4 {
+  .@{breakpoint-prefix}z4 {
     z-index: @z-index-4 !important;
   }
 
-  .xs-z5 {
+  .@{breakpoint-prefix}z5 {
     z-index: @z-index-5 !important;
   }
 
-  .xs-z6 {
+  .@{breakpoint-prefix}z6 {
     z-index: @z-index-6 !important;
   }
 
-  .xs-z7 {
+  .@{breakpoint-prefix}z7 {
     z-index: @z-index-7 !important;
   }
 
-  .xs-z8 {
+  .@{breakpoint-prefix}z8 {
     z-index: @z-index-8 !important;
   }
 
-  .xs-z9 {
+  .@{breakpoint-prefix}z9 {
     z-index: @z-index-9 !important;
   }
 
-  .xs-z10 {
-    z-index: @z-index-10 !important;
-  }
-
-},{
-  .sm-z1 {
-    z-index: @z-index-1 !important;
-  }
-
-  .sm-z2 {
-    z-index: @z-index-2 !important;
-  }
-
-  .sm-z3 {
-    z-index: @z-index-3 !important;
-  }
-
-  .sm-z4 {
-    z-index: @z-index-4 !important;
-  }
-
-  .sm-z5 {
-    z-index: @z-index-5 !important;
-  }
-
-  .sm-z6 {
-    z-index: @z-index-6 !important;
-  }
-
-  .sm-z7 {
-    z-index: @z-index-7 !important;
-  }
-
-  .sm-z8 {
-    z-index: @z-index-8 !important;
-  }
-
-  .sm-z9 {
-    z-index: @z-index-9 !important;
-  }
-
-  .sm-z10 {
-    z-index: @z-index-10 !important;
-  }
-},{
-  .md-z1 {
-    z-index: @z-index-1 !important;
-  }
-
-  .md-z2 {
-    z-index: @z-index-2 !important;
-  }
-
-  .md-z3 {
-    z-index: @z-index-3 !important;
-  }
-
-  .md-z4 {
-    z-index: @z-index-4 !important;
-  }
-
-  .md-z5 {
-    z-index: @z-index-5 !important;
-  }
-
-  .md-z6 {
-    z-index: @z-index-6 !important;
-  }
-
-  .md-z7 {
-    z-index: @z-index-7 !important;
-  }
-
-  .md-z8 {
-    z-index: @z-index-8 !important;
-  }
-
-  .md-z9 {
-    z-index: @z-index-9 !important;
-  }
-
-  .md-z10 {
-    z-index: @z-index-10 !important;
-  }
-},{
-  .lg-z1 {
-    z-index: @z-index-1 !important;
-  }
-
-  .lg-z2 {
-    z-index: @z-index-2 !important;
-  }
-
-  .lg-z3 {
-    z-index: @z-index-3 !important;
-  }
-
-  .lg-z4 {
-    z-index: @z-index-4 !important;
-  }
-
-  .lg-z5 {
-    z-index: @z-index-5 !important;
-  }
-
-  .lg-z6 {
-    z-index: @z-index-6 !important;
-  }
-
-  .lg-z7 {
-    z-index: @z-index-7 !important;
-  }
-
-  .lg-z8 {
-    z-index: @z-index-8 !important;
-  }
-
-  .lg-z9 {
-    z-index: @z-index-9 !important;
-  }
-
-  .lg-z10 {
-    z-index: @z-index-10 !important;
-  }
-},{
-  .xl-z1 {
-    z-index: @z-index-1 !important;
-  }
-
-  .xl-z2 {
-    z-index: @z-index-2 !important;
-  }
-
-  .xl-z3 {
-    z-index: @z-index-3 !important;
-  }
-
-  .xl-z4 {
-    z-index: @z-index-4 !important;
-  }
-
-  .xl-z5 {
-    z-index: @z-index-5 !important;
-  }
-
-  .xl-z6 {
-    z-index: @z-index-6 !important;
-  }
-
-  .xl-z7 {
-    z-index: @z-index-7 !important;
-  }
-
-  .xl-z8 {
-    z-index: @z-index-8 !important;
-  }
-
-  .xl-z9 {
-    z-index: @z-index-9 !important;
-  }
-
-  .xl-z10 {
-    z-index: @z-index-10 !important;
-  }
-},{
-  .xxl-z1 {
-    z-index: @z-index-1 !important;
-  }
-
-  .xxl-z2 {
-    z-index: @z-index-2 !important;
-  }
-
-  .xxl-z3 {
-    z-index: @z-index-3 !important;
-  }
-
-  .xxl-z4 {
-    z-index: @z-index-4 !important;
-  }
-
-  .xxl-z5 {
-    z-index: @z-index-5 !important;
-  }
-
-  .xxl-z6 {
-    z-index: @z-index-6 !important;
-  }
-
-  .xxl-z7 {
-    z-index: @z-index-7 !important;
-  }
-
-  .xxl-z8 {
-    z-index: @z-index-8 !important;
-  }
-
-  .xxl-z9 {
-    z-index: @z-index-9 !important;
-  }
-
-  .xxl-z10 {
+  .@{breakpoint-prefix}z10 {
     z-index: @z-index-10 !important;
   }
 });


### PR DESCRIPTION
The breakpoint classes in cardinal are all manually added for each breakpoint in the Less source. This makes updating classes pretty cumbersome and error prone as well as adding a lot of bloat to the source. I've written a mixin that generates these breakpoint classes so they only need to be written once.

It can be used like this:
```
.breakpoint-prefixes({
  .@{breakpoint-prefix}my-class{ background: red; }
});
```
to generate this CSS:
```
.my-class {
  background: red;
}
@media (min-width: 480px) {
  .xs-my-class {
    background: red;
  }
}
@media (min-width: 600px) {
  .sm-my-class {
    background: red;
  }
}
@media (min-width: 768px) {
  .md-my-class {
    background: red;
  }
}
@media (min-width: 960px) {
  .lg-my-class {
    background: red;
  }
}
@media (min-width: 1140px) {
  .xl-my-class {
    background: red;
  }
}
@media (min-width: 1380px) {
  .xxl-my-class {
    background: red;
  }
}

```
This pull request replaces 5,258 lines of Less with 316 while maintaining 100% functionally identical CSS output.